### PR TITLE
Handle missing ffmpeg gracefully

### DIFF
--- a/run_scan.sh
+++ b/run_scan.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source .venv/bin/activate
+python scan_drive.py "$@"

--- a/scan_drive.py
+++ b/scan_drive.py
@@ -14,6 +14,14 @@ else:
 _blake3_spec = importlib.util.find_spec("blake3")
 _blake3_hash = importlib.import_module("blake3").blake3 if _blake3_spec is not None else None
 
+
+def _has_cmd(cmd: str) -> bool:
+    """Return True if *cmd* is available on PATH."""
+    return shutil.which(cmd) is not None
+
+
+_ffmpeg_available = _has_cmd("ffmpeg")
+
 VIDEO_EXTS = {'.mp4','.mkv','.avi','.mov','.wmv','.m4v','.ts','.m2ts','.webm','.mpg','.mpeg'}
 
 def run(cmd:list[str]) -> tuple[int,str,str]:
@@ -32,6 +40,9 @@ def mediainfo_json(file_path: str) -> Optional[dict]:
 
 def ffmpeg_verify(file_path: str) -> bool:
     if not any(file_path.lower().endswith(e) for e in VIDEO_EXTS):
+        return True
+    if not _ffmpeg_available:
+        # ffmpeg absent: skip verification instead of marking files as invalid
         return True
     # -v error: only show errors; -xerror: stop on error
     code, out, err = run(["ffmpeg","-v","error","-xerror","-i",file_path,"-f","null","-","-nostdin"])


### PR DESCRIPTION
## Summary
- ensure the scanner skips ffmpeg integrity checks when the binary is unavailable so files are not incorrectly marked as corrupt
- fix the helper shell script to invoke the in-repo scan_drive.py entry point with forwarded arguments

## Testing
- python -m compileall scan_drive.py

------
https://chatgpt.com/codex/tasks/task_e_68e41bd222088327b46c36613ca22dec