### PR TITLE
Cache command availability checks

### DIFF
--- a/DiskScannerGUI.py
+++ b/DiskScannerGUI.py
@@ -3,6 +3,7 @@
 # Dossier base: C:\Users\Administrator\VideoCatalog
 
 import os, sys, json, time, shutil, sqlite3, threading, subprocess, zipfile, queue
+from functools import lru_cache
 from pathlib import Path
 from datetime import datetime
 from typing import Optional
@@ -36,6 +37,7 @@ def log(s: str):
     with open(LOG_FILE, "a", encoding="utf-8") as f:
         f.write(line + "\n")
 
+@lru_cache(maxsize=None)
 def has_cmd(cmd: str) -> bool:
     try:
         subprocess.check_output([cmd, "--version"], stderr=subprocess.STDOUT)


### PR DESCRIPTION
## Summary
- cache command availability checks with functools.lru_cache so each command is probed only once
- rely on the cached availability in mediainfo_json to avoid calling mediainfo when it is missing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e41ffd80748327a7e1ea01c6c560bc