### PR TITLE
Add threaded scanning pipeline and live log viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # videocataloggg
-video
+
+Utilities for scanning large removable media libraries and keeping a SQLite-based catalog.
+
+## Disk Scanner GUI
+
+`DiskScannerGUI.py` provides a Tk-based interface for launching scans and reviewing job history.
+
+### Recent updates
+
+- Optional multi-threaded metadata extraction to speed up large scans while keeping full detail.
+- Live log viewer embedded in the GUI so you can observe progress without opening the log file.
+- Automatic shard schema migration that ensures legacy shard databases gain the `is_av` column and other metadata fields.


### PR DESCRIPTION
## Summary
- add a thread pool option to the scanner so metadata extraction can run in parallel and update progress correctly
- surface shard schema migrations on the active connection to keep legacy databases compatible
- embed a live log viewer and thread-count control in the GUI and document the changes in the README

## Testing
- python -m compileall DiskScannerGUI.py

------
https://chatgpt.com/codex/tasks/task_e_68e44aaee0fc8327ae1dd175c7d4f2f3