### PR TITLE
Fix mediainfo availability flag regression

### DIFF
--- a/scan_drive.py
+++ b/scan_drive.py
@@ -37,6 +37,7 @@ def run(cmd:list[str]) -> tuple[int,str,str]:
         return 127, "", str(exc)
 
 def mediainfo_json(file_path: str) -> Optional[dict]:
+    global _mediainfo_available
     if not _mediainfo_available:
         return None
     code, out, err = run(["mediainfo", "--Output=JSON", file_path])
@@ -47,7 +48,6 @@ def mediainfo_json(file_path: str) -> Optional[dict]:
             return None
     if code == 127:
         # Command missing – treat as unavailable for the remainder of the scan
-        global _mediainfo_available
         _mediainfo_available = False
     return None
 


### PR DESCRIPTION
## Summary
- declare `_mediainfo_available` as global at the top of the helper so the module compiles again

## Testing
- python -m compileall DiskScannerGUI.py scan_drive.py
- python - <<'PY'
import tempfile, sqlite3, os
from pathlib import Path
from scan_drive import scan_drive

with tempfile.TemporaryDirectory() as tmp:
    mount = Path(tmp)
    (mount / 'video.mp4').write_bytes(b'FAKE DATA')
    db_path = Path(tmp) / 'catalog.db'
    scan_drive('TEST', str(mount), str(db_path))
    con = sqlite3.connect(db_path)
    cur = con.cursor()
    cur.execute('SELECT drive_label, COUNT(*) FROM files GROUP BY drive_label')
    rows = cur.fetchall()
    print(rows)
    con.close()
PY


------
https://chatgpt.com/codex/tasks/task_e_68e46ea5c09883278db9d966c07ded56