### PR TITLE
Fix scan_drive database initialization for new directories

### DIFF
--- a/scan_drive.py
+++ b/scan_drive.py
@@ -75,7 +75,9 @@ def hash_blake3(file_path: str, chunk: int = 1024*1024) -> str:
     return h.hexdigest()
 
 def init_db(db_path: str):
-    conn = sqlite3.connect(db_path)
+    db_path_obj = Path(db_path)
+    db_path_obj.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path_obj))
     c = conn.cursor()
     c.executescript("""
     PRAGMA journal_mode=WAL;


### PR DESCRIPTION
## Summary
- ensure scan_drive creates the parent directory for the catalog database before opening it

## Testing
- python -m py_compile scan_drive.py

------
https://chatgpt.com/codex/tasks/task_e_68e46ffab648832789810a5b6a8fa4d0