### PR TITLE
Implement dynamic working directory resolution and harden PowerShell scripts

### DIFF
--- a/launch-gui.ps1
+++ b/launch-gui.ps1
@@ -1,7 +1,23 @@
-﻿# Launch Disk Scanner GUI (clean)
-$Base   = "C:\Users\Administrator\VideoCatalog"
-$VenvPy = Join-Path $Base "venv\Scripts\python.exe"
-$Gui    = Join-Path $Base "DiskScannerGUI.py"
+[CmdletBinding()]
+param()
 
-Set-Location $Base
-powershell -NoProfile -ExecutionPolicy Bypass -Command "& `"$VenvPy`" `"$Gui`""
+$ErrorActionPreference = 'Stop'
+$scriptRoot = $PSScriptRoot
+$python = Join-Path $scriptRoot '.venv\Scripts\python.exe'
+if (-not (Test-Path -Path $python)) {
+    $python = 'python'
+}
+
+$guiScript = Join-Path $scriptRoot 'DiskScannerGUI.py'
+
+try {
+    & $python $guiScript
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        Write-Error "Disk Scanner GUI exited with code $exitCode."
+        exit 1
+    }
+} catch {
+    Write-Error $_
+    exit 1
+}

--- a/paths.py
+++ b/paths.py
@@ -1,0 +1,213 @@
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+_PROJECT_ROOT = Path(__file__).resolve().parent
+
+
+def _expand_path(value: str) -> Path:
+    expanded = os.path.expandvars(os.path.expanduser(value))
+    return Path(expanded).resolve()
+
+
+def _ensure_writable_dir(path: Path) -> bool:
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+    except Exception:
+        return False
+    test_file = path / f".write_test_{os.getpid()}"
+    try:
+        with open(test_file, "w", encoding="utf-8") as handle:
+            handle.write("ok")
+        test_file.unlink(missing_ok=True)
+        return True
+    except Exception:
+        try:
+            if test_file.exists():
+                test_file.unlink()
+        except Exception:
+            pass
+        return False
+
+
+def _prepare_working_dir(candidate: Path) -> Optional[Path]:
+    if not _ensure_writable_dir(candidate):
+        return None
+    try:
+        data_dir = candidate / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        return candidate
+    except Exception:
+        return None
+
+
+def _read_settings(path: Path) -> Optional[Dict[str, Any]]:
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            data = json.load(handle)
+        if isinstance(data, dict):
+            return data
+    except FileNotFoundError:
+        return None
+    except Exception:
+        return None
+    return None
+
+
+def _program_data_dir() -> Optional[Path]:
+    program_data = os.environ.get("ProgramData")
+    if not program_data:
+        return None
+    try:
+        return _expand_path(program_data)
+    except Exception:
+        return None
+
+
+def _local_appdata_dir() -> Path:
+    local_appdata = os.environ.get("LOCALAPPDATA")
+    if local_appdata:
+        try:
+            return _expand_path(local_appdata)
+        except Exception:
+            pass
+    # Fallback for non-Windows environments
+    return Path.home() / ".videocatalog"
+
+
+def resolve_working_dir() -> Path:
+    """Resolve the working directory according to the configured precedence."""
+    env_home = os.environ.get("VIDEOCATALOG_HOME")
+    if env_home:
+        try:
+            env_path = _expand_path(env_home)
+        except Exception:
+            env_path = None
+        if env_path:
+            prepared = _prepare_working_dir(env_path)
+            if prepared is not None:
+                return prepared
+
+    legacy_settings_paths = [
+        _PROJECT_ROOT / "settings.json",
+    ]
+    program_data = _program_data_dir()
+    if program_data is not None:
+        legacy_settings_paths.append(program_data / "VideoCatalog" / "settings.json")
+
+    for legacy_path in legacy_settings_paths:
+        data = _read_settings(legacy_path)
+        if not data:
+            continue
+        working_dir_value = data.get("working_dir")
+        candidate_path: Optional[Path] = None
+        if isinstance(working_dir_value, str) and working_dir_value.strip():
+            try:
+                candidate_path = _expand_path(working_dir_value)
+            except Exception:
+                candidate_path = None
+        if candidate_path is None:
+            catalog_db = data.get("catalog_db")
+            if isinstance(catalog_db, str) and catalog_db.strip():
+                try:
+                    catalog_path = _expand_path(catalog_db)
+                    parent = catalog_path.parent
+                    if parent.name.lower() == "data":
+                        candidate_path = parent.parent
+                    else:
+                        candidate_path = parent
+                except Exception:
+                    candidate_path = None
+        if candidate_path is not None:
+            prepared = _prepare_working_dir(candidate_path)
+            if prepared is not None:
+                return prepared
+
+    if program_data is not None:
+        pd_candidate = program_data / "VideoCatalog"
+        prepared = _prepare_working_dir(pd_candidate)
+        if prepared is not None:
+            return prepared
+
+    local_base = _local_appdata_dir()
+    prepared = _prepare_working_dir(local_base / "VideoCatalog")
+    if prepared is not None:
+        return prepared
+
+    # Final fallback: ensure the home-based directory exists even if creation failed above.
+    fallback = Path.home() / "VideoCatalog"
+    fallback.mkdir(parents=True, exist_ok=True)
+    (fallback / "data").mkdir(parents=True, exist_ok=True)
+    return fallback
+
+
+def get_data_dir(working_dir: Path) -> Path:
+    return working_dir / "data"
+
+
+def get_catalog_db_path(working_dir: Path) -> Path:
+    return get_data_dir(working_dir) / "catalog.db"
+
+
+def get_shards_dir(working_dir: Path) -> Path:
+    return get_data_dir(working_dir) / "shards"
+
+
+def get_logs_dir(working_dir: Path) -> Path:
+    return working_dir / "logs"
+
+
+def get_scans_dir(working_dir: Path) -> Path:
+    return working_dir / "scans"
+
+
+def get_exports_dir(working_dir: Path) -> Path:
+    return working_dir / "exports"
+
+
+def get_drive_types_path(working_dir: Path) -> Path:
+    return working_dir / "drive_types.json"
+
+
+def ensure_working_dir_structure(working_dir: Path) -> None:
+    for directory in (
+        working_dir,
+        get_data_dir(working_dir),
+        get_shards_dir(working_dir),
+        get_logs_dir(working_dir),
+        get_scans_dir(working_dir),
+        get_exports_dir(working_dir),
+    ):
+        directory.mkdir(parents=True, exist_ok=True)
+
+
+def load_settings(working_dir: Path) -> Dict[str, Any]:
+    search_paths = [
+        get_data_dir(working_dir).parent / "settings.json",  # equals working_dir / "settings.json"
+    ]
+    program_data = _program_data_dir()
+    if program_data is not None:
+        search_paths.append(program_data / "VideoCatalog" / "settings.json")
+    search_paths.append(_PROJECT_ROOT / "settings.json")
+
+    for candidate in search_paths:
+        data = _read_settings(candidate)
+        if data:
+            return data
+    return {}
+
+
+def save_settings(settings: Dict[str, Any], working_dir: Path) -> None:
+    settings_path = working_dir / "settings.json"
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    to_write = dict(settings)
+    to_write.setdefault("working_dir", str(working_dir))
+    with open(settings_path, "w", encoding="utf-8") as handle:
+        json.dump(to_write, handle, ensure_ascii=False, indent=2)
+
+
+def update_settings(working_dir: Path, **values: Any) -> None:
+    current = load_settings(working_dir)
+    current.update(values)
+    save_settings(current, working_dir)

--- a/scan-drive.ps1
+++ b/scan-drive.ps1
@@ -1,6 +1,48 @@
-﻿param(
-  [Parameter(Mandatory=\True)][string]\,
-  [Parameter(Mandatory=\True)][string]\,
-  [string]\ = "C:\Users\Administrator\VideoCatalog\catalog.db"
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$Label,
+    [Parameter(Mandatory = $true)][string]$MountPath,
+    [string]$CatalogPath,
+    [switch]$DebugSlowEnumeration
 )
-"C:\Users\Administrator\VideoCatalog\venv\Scripts\python.exe" "C:\Users\Administrator\VideoCatalog\scan_drive.py" "" "" ""
+
+$ErrorActionPreference = 'Stop'
+$scriptRoot = $PSScriptRoot
+$python = Join-Path $scriptRoot '.venv\Scripts\python.exe'
+if (-not (Test-Path -Path $python)) {
+    $python = 'python'
+}
+
+$scanScript = Join-Path $scriptRoot 'scan_drive.py'
+if (-not (Test-Path -Path $scanScript)) {
+    Write-Error "scan_drive.py not found at $scanScript."
+    exit 1
+}
+
+try {
+    if (-not $CatalogPath) {
+        $CatalogPath = & $python -c "from paths import resolve_working_dir, ensure_working_dir_structure, get_catalog_db_path; wd = resolve_working_dir(); ensure_working_dir_structure(wd); print(get_catalog_db_path(wd))"
+        $determineExit = $LASTEXITCODE
+        if ($determineExit -ne 0 -or [string]::IsNullOrWhiteSpace($CatalogPath)) {
+            throw 'Failed to determine default catalog path.'
+        }
+        $CatalogPath = $CatalogPath.Trim()
+    }
+} catch {
+    Write-Error $_
+    exit 1
+}
+
+$arguments = @($scanScript, $Label, $MountPath, $CatalogPath)
+if ($DebugSlowEnumeration.IsPresent) {
+    $arguments += '--debug-slow-enumeration'
+}
+
+& $python @arguments
+$exitCode = $LASTEXITCODE
+if ($exitCode -ne 0) {
+    Write-Error "scan_drive.py exited with code $exitCode."
+    exit $exitCode
+}
+
+exit 0

--- a/scan_drive.py
+++ b/scan_drive.py
@@ -4,6 +4,16 @@ from pathlib import Path
 from typing import Optional
 import hashlib
 
+from paths import (
+    ensure_working_dir_structure,
+    get_catalog_db_path,
+    resolve_working_dir,
+)
+
+WORKING_DIR_PATH = resolve_working_dir()
+ensure_working_dir_structure(WORKING_DIR_PATH)
+DEFAULT_DB_PATH = str(get_catalog_db_path(WORKING_DIR_PATH))
+
 _tqdm_spec = importlib.util.find_spec("tqdm")
 if _tqdm_spec is None:
     def tqdm(iterable, **kwargs):
@@ -190,8 +200,11 @@ if __name__ == "__main__":
     if "--debug-slow-enumeration" in args:
         args.remove("--debug-slow-enumeration")
         debug_flag = True
-    if len(args) != 3:
-        print("Usage: python scan_drive.py <LABEL> <MOUNT_PATH> <DB_PATH>")
+    if len(args) not in (2, 3):
+        script_name = Path(__file__).name
+        print(f"Usage: python {script_name} <LABEL> <MOUNT_PATH> [<DB_PATH>]")
+        print(f"       Default DB path: {DEFAULT_DB_PATH}")
         sys.exit(1)
-    label, mount_path, db_path = args
+    label, mount_path = args[:2]
+    db_path = args[2] if len(args) == 3 else DEFAULT_DB_PATH
     scan_drive(label, mount_path, db_path, debug_slow=debug_flag)


### PR DESCRIPTION
## Summary
- add a shared `paths` utility to resolve the working directory, manage settings, and provision required folders
- update the GUI and CLI entry points to use the new path helpers and persist the selected catalog database location
- rewrite the PowerShell launchers to locate the repository via `$PSScriptRoot`, respect optional virtual environments, and propagate Python exit codes clearly

## Testing
- python -m compileall DiskScannerGUI.py scan_drive.py paths.py


------
https://chatgpt.com/codex/tasks/task_e_68e59bb3df3483279b430601c3da14f3