### PR TITLE
Paths: deterministic working dir resolution and robust PowerShell wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ Utilities for scanning large removable media libraries and keeping a SQLite-base
 - Live log viewer embedded in the GUI so you can observe progress without opening the log file.
 - Automatic shard schema migration that ensures legacy shard databases gain the `is_av` column and other metadata fields.
 
+## Paths & working directory
+
+The scanner now resolves its working directory deterministically:
+
+1. `VIDEOCATALOG_HOME` (if set and writable).
+2. `settings.json` located under the working directory itself, `%ProgramData%\VideoCatalog`, or the project root (legacy, read-only).
+3. Default fallback: `%ProgramData%\VideoCatalog` when writable, otherwise `%LOCALAPPDATA%\VideoCatalog`.
+
+All runtime assets live beneath `<working_dir>/data` by default, including `catalog.db` and the per-drive shard databases under `<working_dir>/data/shards/`.
+
+PowerShell entry points (`launch-gui.ps1` and `scan-drive.ps1`) automatically locate the repository via `$PSScriptRoot`, honor local virtual environments, and forward arguments safely so UNC paths and spaces are supported out of the box.
+
 ## Troubleshooting
 
 - A red banner across the top of the window means a required media tool is missing. Install `mediainfo` and `ffmpeg` before launching a new scan. An installer will take care of these dependencies in a future release.

--- a/launch-gui.ps1
+++ b/launch-gui.ps1
@@ -2,22 +2,29 @@
 param()
 
 $ErrorActionPreference = 'Stop'
+
 $scriptRoot = $PSScriptRoot
-$python = Join-Path $scriptRoot '.venv\Scripts\python.exe'
-if (-not (Test-Path -Path $python)) {
-    $python = 'python'
+$pythonExe = Join-Path -Path $scriptRoot -ChildPath '.venv\Scripts\python.exe'
+if (-not (Test-Path -LiteralPath $pythonExe)) {
+    $pythonExe = 'python'
 }
 
-$guiScript = Join-Path $scriptRoot 'DiskScannerGUI.py'
+$guiScript = Join-Path -Path $scriptRoot -ChildPath 'DiskScannerGUI.py'
+if (-not (Test-Path -LiteralPath $guiScript)) {
+    Write-Error "Unable to locate DiskScannerGUI.py at $guiScript."
+    exit 1
+}
 
 try {
-    & $python $guiScript
+    & $pythonExe $guiScript
     $exitCode = $LASTEXITCODE
     if ($exitCode -ne 0) {
-        Write-Error "Disk Scanner GUI exited with code $exitCode."
+        Write-Error "DiskScannerGUI exited with code $exitCode."
         exit 1
     }
 } catch {
     Write-Error $_
     exit 1
 }
+
+exit 0


### PR DESCRIPTION
## Summary
- implement deterministic working-directory resolution shared by the GUI and CLI, ensuring catalog and shard databases live under `<working_dir>/data` and logging the resolved locations at startup
- sanitize shard filenames in the GUI so drives always map to safe paths under `data/shards`
- harden the PowerShell launch scripts to locate the repo via `$PSScriptRoot`, respect virtual environments, and pass arguments safely; document the new path-precedence rules in the README

## Testing
- python -m compileall DiskScannerGUI.py scan_drive.py paths.py

------
https://chatgpt.com/codex/tasks/task_e_68e59e7400ac8327b20518e38527c0cb