### PR TITLE
Add local read-only FastAPI service with GUI toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,23 @@ Utilities for scanning large removable media libraries and keeping a SQLite-base
 - Results return the latest 1,000 matches with name, category, size, modified time, drive label, and full path. Double-click opens the file's folder in Explorer, the context menu can copy the full path, and exports land as CSV/JSONL under `<working_dir>/exports`.
 - The first search against an older shard performs a lightweight migration that backfills the lowercase `inventory.name` column and index; if migration fails the UI falls back to path-only matching and surfaces the error.
 
+## Local read-only API
+
+- Launch the service directly with `python videocatalog_api.py --api-key <KEY>` (optional `--host`, `--port`, and repeated `--cors` flags override `settings.json`). On start the CLI prints `API listening on http://<host>:<port>` so other tools can probe it locally.
+- The GUI exposes a **Start Local API** toggle under the Database card. It shows host/port plus whether an API key is configured and runs the server in a background process. Disable it from the same button or let it auto-start when `settings.json` sets `"api.enabled_default": true`.
+- All endpoints are GET-only, paginate with `limit`/`offset`, and require an `X-API-Key` header. Missing or empty keys return `401 Unauthorized`. Defaults bind to `127.0.0.1:8756`; expanding beyond localhost or exposing the API externally is at your own risk.
+- Example requests:
+
+  ```bash
+  curl -H "X-API-Key: $VIDEOCATALOG_API_KEY" http://127.0.0.1:8756/v1/health
+  curl -H "X-API-Key: $VIDEOCATALOG_API_KEY" \
+       "http://127.0.0.1:8756/v1/inventory?drive_label=MyDrive&limit=25&q=hdr"
+  curl -H "X-API-Key: $VIDEOCATALOG_API_KEY" \
+       "http://127.0.0.1:8756/v1/features/vector?drive_label=MyDrive&path=movies/clip.mp4&raw=true"
+  ```
+
+- Configure behaviour under the `"api"` section of `settings.json` (host, port, API key, allowed CORS origins, default page size). Pagination caps at `max_page_size`, and `/v1/features/vector` enforces a dimensionality guard unless `?raw=true` is supplied to download large vectors explicitly.
+
 ## Rescan modes
 
 The scanner now supports two rescan strategies when revisiting a drive:

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,7 @@
+"""Local read-only API package for VideoCatalog."""
+
+__all__ = [
+    "__version__",
+]
+
+__version__ = "0.1.0"

--- a/api/auth.py
+++ b/api/auth.py
@@ -1,0 +1,32 @@
+"""Simple header-based authentication for the local API."""
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import Depends, Header, HTTPException, status
+
+
+class APIKeyAuth:
+    """Dependency enforcing a static API key provided via ``X-API-Key`` header."""
+
+    def __init__(self, expected_key: Optional[str]) -> None:
+        self._expected = (expected_key or "").strip()
+
+    def __call__(self, x_api_key: Optional[str] = Header(None)) -> str:
+        if not self._expected:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="API key is not configured.",
+            )
+        if not x_api_key or x_api_key.strip() != self._expected:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid or missing API key.",
+            )
+        return self._expected
+
+
+def require_api_key(auth: APIKeyAuth = Depends()) -> str:
+    """Convenience dependency mirroring FastAPI's dependency resolution."""
+
+    return auth()

--- a/api/db.py
+++ b/api/db.py
@@ -1,0 +1,460 @@
+"""Read-only SQLite helpers for the VideoCatalog local API."""
+from __future__ import annotations
+
+import os
+import sqlite3
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple
+
+from paths import (
+    get_catalog_db_path,
+    get_shard_db_path,
+    get_shards_dir,
+    load_settings,
+    resolve_working_dir,
+)
+
+_DEFAULT_LIMIT = 100
+_MAX_PAGE_SIZE = 500
+_COUNT_GUARD = 10000
+
+
+@dataclass(slots=True)
+class Pagination:
+    """Resolved pagination values after clamping settings and user input."""
+
+    limit: int
+    offset: int
+
+
+class DataAccess:
+    """Central access layer for catalog and shard databases."""
+
+    def __init__(
+        self,
+        *,
+        working_dir: Optional[Path] = None,
+        settings: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.working_dir = Path(working_dir or resolve_working_dir())
+        self._settings = dict(settings or load_settings(self.working_dir))
+        self.catalog_path = self._resolve_catalog_path()
+        self.shards_dir = get_shards_dir(self.working_dir)
+        api_settings = (
+            self._settings.get("api") if isinstance(self._settings.get("api"), dict) else {}
+        )
+        default_limit = int(api_settings.get("default_limit") or _DEFAULT_LIMIT)
+        max_page = int(api_settings.get("max_page_size") or _MAX_PAGE_SIZE)
+        if default_limit <= 0:
+            default_limit = _DEFAULT_LIMIT
+        if max_page <= 0:
+            max_page = _MAX_PAGE_SIZE
+        self.default_limit = min(default_limit, max_page)
+        self.max_page_size = max_page
+    def refresh_settings(self) -> None:
+        """Reload settings.json from disk."""
+
+        self._settings = load_settings(self.working_dir)
+        api_settings = (
+            self._settings.get("api") if isinstance(self._settings.get("api"), dict) else {}
+        )
+        default_limit = int(api_settings.get("default_limit") or _DEFAULT_LIMIT)
+        max_page = int(api_settings.get("max_page_size") or _MAX_PAGE_SIZE)
+        if default_limit <= 0:
+            default_limit = _DEFAULT_LIMIT
+        if max_page <= 0:
+            max_page = _MAX_PAGE_SIZE
+        self.default_limit = min(default_limit, max_page)
+        self.max_page_size = max_page
+
+    def _resolve_catalog_path(self) -> Path:
+        settings_value = self._settings.get("catalog_db")
+        if isinstance(settings_value, str) and settings_value.strip():
+            candidate = self._expand_user_path(settings_value.strip())
+            if candidate:
+                return candidate
+        return get_catalog_db_path(self.working_dir)
+
+    def _expand_user_path(self, value: str) -> Path:
+        expanded = os.path.expandvars(os.path.expanduser(value))
+        path = Path(expanded)
+        if not path.is_absolute():
+            path = self.working_dir / path
+        return path.resolve()
+
+    @contextmanager
+    def _catalog(self) -> Iterator[sqlite3.Connection]:
+        conn = self._connect(self.catalog_path)
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    @contextmanager
+    def _shard(self, drive_label: str) -> Iterator[sqlite3.Connection]:
+        shard_path = self._shard_path_for(drive_label)
+        conn = self._connect(shard_path)
+        conn.create_function("BASENAME", 1, _lower_basename)
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    def _shard_path_for(self, drive_label: str) -> Path:
+        if not drive_label:
+            raise LookupError("unknown drive_label")
+        shard_path = get_shard_db_path(self.working_dir, drive_label)
+        if not shard_path.exists():
+            with self._catalog() as conn:
+                cur = conn.execute(
+                    "SELECT 1 FROM drives WHERE label = ? LIMIT 1",
+                    (drive_label,),
+                )
+                if cur.fetchone() is None:
+                    raise LookupError("unknown drive_label")
+            raise FileNotFoundError(f"shard not found for drive_label={drive_label!r}")
+        return shard_path
+
+    def _connect(self, path: Path) -> sqlite3.Connection:
+        uri_path = path.resolve()
+        try:
+            conn = sqlite3.connect(
+                f"file:{uri_path.as_posix()}?mode=ro&cache=shared",
+                uri=True,
+                check_same_thread=False,
+            )
+        except sqlite3.OperationalError:
+            conn = sqlite3.connect(str(uri_path), check_same_thread=False)
+            try:
+                conn.execute("PRAGMA query_only = 1")
+            except sqlite3.DatabaseError:
+                pass
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def resolve_pagination(self, limit: Optional[int], offset: Optional[int]) -> Pagination:
+        try:
+            lim = int(limit) if limit is not None else self.default_limit
+        except (TypeError, ValueError):
+            lim = self.default_limit
+        try:
+            off = int(offset or 0)
+        except (TypeError, ValueError):
+            off = 0
+        lim = max(1, min(lim, self.max_page_size))
+        off = max(0, off)
+        return Pagination(limit=lim, offset=off)
+    def list_drives(self) -> List[Dict[str, Any]]:
+        rows: List[Dict[str, Any]] = []
+        with self._catalog() as conn:
+            cursor = conn.execute(
+                """
+                SELECT label,
+                       NULLIF(TRIM(COALESCE(drive_type, '')),'') AS drive_type,
+                       NULLIF(TRIM(COALESCE(scanned_at, '')),'') AS scanned_at
+                FROM drives
+                ORDER BY label COLLATE NOCASE ASC
+                """
+            )
+            for row in cursor.fetchall():
+                label = row["label"]
+                rows.append(
+                    {
+                        "label": label,
+                        "type": row["drive_type"],
+                        "last_scan_utc": row["scanned_at"],
+                        "shard_path": str(get_shard_db_path(self.working_dir, label)),
+                    }
+                )
+        return rows
+
+    def inventory_page(
+        self,
+        drive_label: str,
+        *,
+        q: Optional[str] = None,
+        category: Optional[str] = None,
+        ext: Optional[str] = None,
+        mime: Optional[str] = None,
+        since: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+    ) -> Tuple[List[Dict[str, Any]], Pagination, Optional[int], Optional[int]]:
+        pagination = self.resolve_pagination(limit, offset)
+        clauses: List[str] = []
+        params: List[Any] = []
+        if q:
+            pattern = f"%{q.lower()}%"
+            clauses.append("(LOWER(path) LIKE ? OR BASENAME(path) LIKE ?)")
+            params.extend([pattern, pattern])
+        if category:
+            clauses.append("LOWER(COALESCE(category,'')) = ?")
+            params.append(category.lower())
+        if ext:
+            clauses.append("LOWER(COALESCE(ext,'')) = ?")
+            params.append(ext.lower())
+        if mime:
+            clauses.append("LOWER(COALESCE(mime,'')) LIKE ?")
+            params.append(f"{mime.lower()}%")
+        if since:
+            normalized = _normalize_iso8601(since)
+            clauses.append("mtime_utc >= ?")
+            params.append(normalized)
+        where_sql = " WHERE " + " AND ".join(clauses) if clauses else ""
+        results: List[Dict[str, Any]] = []
+        next_offset: Optional[int] = None
+        total_estimate: Optional[int] = None
+        with self._shard(drive_label) as conn:
+            limit_plus = pagination.limit + 1
+            cursor = conn.execute(
+                f"""
+                SELECT path, size_bytes, mtime_utc, category, drive_label, ext, mime
+                FROM inventory
+                {where_sql}
+                ORDER BY path COLLATE NOCASE ASC
+                LIMIT ? OFFSET ?
+                """,
+                (*params, limit_plus, pagination.offset),
+            )
+            fetched = cursor.fetchall()
+            if len(fetched) > pagination.limit:
+                fetched = fetched[: pagination.limit]
+                next_offset = pagination.offset + pagination.limit
+            for row in fetched:
+                path_value = row["path"]
+                results.append(
+                    {
+                        "path": path_value,
+                        "name": _basename(path_value),
+                        "category": row["category"],
+                        "size_bytes": int(row["size_bytes"] or 0),
+                        "mtime_utc": row["mtime_utc"],
+                        "drive_label": row["drive_label"],
+                        "ext": row["ext"],
+                        "mime": row["mime"],
+                    }
+                )
+            total_estimate = self._estimate_total(conn, "inventory", clauses, params)
+        return results, pagination, next_offset, total_estimate
+    def inventory_row(self, drive_label: str, path: str) -> Optional[Dict[str, Any]]:
+        with self._shard(drive_label) as conn:
+            cursor = conn.execute(
+                """
+                SELECT path, size_bytes, mtime_utc, ext, mime, category, drive_label, drive_type, indexed_utc
+                FROM inventory
+                WHERE path = ?
+                LIMIT 1
+                """,
+                (path,),
+            )
+            row = cursor.fetchone()
+            if row is None:
+                return None
+            return {key: row[key] for key in row.keys()}
+
+    def drive_stats(self, drive_label: str) -> Dict[str, Any]:
+        totals: Dict[str, int] = {}
+        total_files = 0
+        scanned_at: Optional[str] = None
+        with self._catalog() as conn:
+            cursor = conn.execute(
+                """
+                SELECT total_files, by_video, by_audio, by_image, by_document, by_archive,
+                       by_executable, by_other, scan_ts_utc
+                FROM inventory_stats
+                WHERE drive_label = ?
+                ORDER BY datetime(scan_ts_utc) DESC
+                LIMIT 1
+                """,
+                (drive_label,),
+            )
+            row = cursor.fetchone()
+            if row is not None:
+                total_files = int(row["total_files"] or 0)
+                totals = {
+                    "video": int(row["by_video"] or 0),
+                    "audio": int(row["by_audio"] or 0),
+                    "image": int(row["by_image"] or 0),
+                    "document": int(row["by_document"] or 0),
+                    "archive": int(row["by_archive"] or 0),
+                    "executable": int(row["by_executable"] or 0),
+                    "other": int(row["by_other"] or 0),
+                }
+                scanned_at = row["scan_ts_utc"]
+        if not totals:
+            totals = {}
+            with self._shard(drive_label) as conn:
+                cursor = conn.execute(
+                    """
+                    SELECT COALESCE(NULLIF(TRIM(category), ''), 'other') AS cat,
+                           COUNT(*) AS count
+                    FROM inventory
+                    GROUP BY cat
+                    """
+                )
+                for row in cursor.fetchall():
+                    category = str(row["cat"])
+                    totals[category] = int(row["count"] or 0)
+                total_files = sum(totals.values())
+        return {
+            "drive_label": drive_label,
+            "totals": {
+                "total_files": total_files,
+                "by_category": totals,
+                "scanned_at_utc": scanned_at,
+            },
+        }
+    def features_page(
+        self,
+        drive_label: str,
+        *,
+        path_query: Optional[str] = None,
+        kind: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+    ) -> Tuple[List[Dict[str, Any]], Pagination, Optional[int], Optional[int]]:
+        pagination = self.resolve_pagination(limit, offset)
+        clauses: List[str] = []
+        params: List[Any] = []
+        if path_query:
+            pattern = f"%{path_query.lower()}%"
+            clauses.append("(LOWER(path) LIKE ? OR BASENAME(path) LIKE ?)")
+            params.extend([pattern, pattern])
+        if kind:
+            clauses.append("LOWER(kind) = ?")
+            params.append(kind.lower())
+        where_sql = " WHERE " + " AND ".join(clauses) if clauses else ""
+        results: List[Dict[str, Any]] = []
+        next_offset: Optional[int] = None
+        total_estimate: Optional[int] = None
+        with self._shard(drive_label) as conn:
+            limit_plus = pagination.limit + 1
+            cursor = conn.execute(
+                f"""
+                SELECT path, kind, dim, frames_used, updated_utc
+                FROM features
+                {where_sql}
+                ORDER BY path COLLATE NOCASE ASC
+                LIMIT ? OFFSET ?
+                """,
+                (*params, limit_plus, pagination.offset),
+            )
+            fetched = cursor.fetchall()
+            if len(fetched) > pagination.limit:
+                fetched = fetched[: pagination.limit]
+                next_offset = pagination.offset + pagination.limit
+            for row in fetched:
+                results.append(
+                    {
+                        "path": row["path"],
+                        "kind": row["kind"],
+                        "dim": int(row["dim"] or 0),
+                        "frames_used": int(row["frames_used"] or 0),
+                        "updated_utc": row["updated_utc"],
+                    }
+                )
+            total_estimate = self._estimate_total(conn, "features", clauses, params)
+        return results, pagination, next_offset, total_estimate
+
+    def feature_vector(self, drive_label: str, path: str) -> Optional[Dict[str, Any]]:
+        with self._shard(drive_label) as conn:
+            cursor = conn.execute(
+                """
+                SELECT path, kind, dim, vec
+                FROM features
+                WHERE path = ?
+                LIMIT 1
+                """,
+                (path,),
+            )
+            row = cursor.fetchone()
+            if row is None:
+                return None
+            dim = int(row["dim"] or 0)
+            blob = row["vec"]
+            vector = _blob_to_floats(blob, dim)
+            return {
+                "path": row["path"],
+                "dim": dim,
+                "kind": row["kind"],
+                "vector": vector,
+            }
+    def _estimate_total(
+        self,
+        conn: sqlite3.Connection,
+        table: str,
+        clauses: Sequence[str],
+        params: Sequence[Any],
+    ) -> Optional[int]:
+        where_sql = " WHERE " + " AND ".join(clauses) if clauses else ""
+        cursor = conn.execute(
+            f"""
+            SELECT COUNT(*) AS count
+            FROM (
+                SELECT 1
+                FROM {table}
+                {where_sql}
+                LIMIT { _COUNT_GUARD + 1 }
+            )
+            """,
+            tuple(params),
+        )
+        count = cursor.fetchone()["count"]
+        if count > _COUNT_GUARD:
+            return None
+        return int(count)
+
+
+def _lower_basename(path_value: Any) -> str:
+    if not isinstance(path_value, str):
+        return ""
+    return _basename(path_value).lower()
+
+
+def _basename(path_value: str) -> str:
+    if not path_value:
+        return ""
+    normalized = path_value.replace("\\", "/")
+    return normalized.rsplit("/", 1)[-1]
+
+
+def _blob_to_floats(blob: Any, dim: int) -> List[float]:
+    if blob is None:
+        return []
+    try:
+        from array import array
+
+        arr = array("f")
+        arr.frombytes(blob)
+        if dim and len(arr) > dim:
+            arr = arr[:dim]
+        return [float(v) for v in arr]
+    except Exception:
+        import struct
+
+        if dim <= 0:
+            dim = len(blob) // 4
+        try:
+            return list(struct.unpack(f"<{dim}f", blob[: dim * 4]))
+        except struct.error:
+            return []
+
+
+def _normalize_iso8601(value: str) -> str:
+    value = value.strip()
+    if not value:
+        return value
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    dt = datetime.fromisoformat(value)
+    dt = dt.astimezone(timezone.utc)
+    return dt.replace(tzinfo=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+__all__ = [
+    "DataAccess",
+    "Pagination",
+]

--- a/api/models.py
+++ b/api/models.py
@@ -1,0 +1,132 @@
+
+"""Pydantic schemas for the VideoCatalog local API."""
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class HealthResponse(BaseModel):
+    """Simple health response with application metadata."""
+
+    ok: bool = Field(True, description="Indicates the API server is reachable.")
+    version: str = Field(..., description="Application version string.")
+    time_utc: str = Field(..., description="Current UTC timestamp in ISO8601 format.")
+
+
+class DriveInfo(BaseModel):
+    """Metadata describing a catalogued drive."""
+
+    label: str = Field(..., description="Drive label as registered in the catalog database.")
+    type: Optional[str] = Field(None, description="Optional drive type preset.")
+    last_scan_utc: Optional[str] = Field(
+        None, description="Timestamp (UTC) of the last completed scan for this drive."
+    )
+    shard_path: str = Field(..., description="Absolute path to the shard SQLite database file.")
+
+
+class PaginatedResponse(BaseModel):
+    """Base schema for paginated list endpoints."""
+
+    limit: int = Field(..., description="Maximum number of rows returned in this page.")
+    offset: int = Field(..., description="Zero-based offset that produced this page.")
+    next_offset: Optional[int] = Field(
+        None,
+        description=(
+            "Offset to request the next page, or null when no more data is immediately available."
+        ),
+    )
+    total_estimate: Optional[int] = Field(
+        None,
+        description=(
+            "Estimated total rows matching the filter when cheaply available; null when omitted."
+        ),
+    )
+
+
+
+class InventoryRow(BaseModel):
+    """Single file entry coming from a drive inventory shard."""
+
+    path: str = Field(..., description="Full path relative to the scanned drive.")
+    name: str = Field(..., description="Basename of the file for convenience.")
+    category: Optional[str] = Field(None, description="Categorised type, e.g. image/audio/video.")
+    size_bytes: int = Field(..., description="File size in bytes.")
+    mtime_utc: str = Field(..., description="Last modification timestamp in UTC (ISO8601).")
+    drive_label: Optional[str] = Field(
+        None, description="Drive label owning this record (mirrors drive_label column)."
+    )
+    ext: Optional[str] = Field(None, description="File extension cached during the scan.")
+    mime: Optional[str] = Field(None, description="MIME guess captured during the scan.")
+
+
+class InventoryResponse(PaginatedResponse):
+    """Paginated inventory listing."""
+
+    results: List[InventoryRow] = Field(..., description="Inventory rows for this page.")
+
+
+class FileResponse(BaseModel):
+    """Single inventory row fetched by path."""
+
+    path: str
+    size_bytes: int
+    mtime_utc: str
+    ext: Optional[str]
+    mime: Optional[str]
+    category: Optional[str]
+    drive_label: Optional[str]
+    drive_type: Optional[str]
+    indexed_utc: Optional[str]
+
+
+class StatsTotals(BaseModel):
+    """Category breakdown for a drive inventory."""
+
+    total_files: int = Field(..., description="Number of inventory rows tallied.")
+    by_category: Dict[str, int] = Field(
+        ..., description="Mapping of category name → count for the latest completed scan."
+    )
+    scanned_at_utc: Optional[str] = Field(
+        None, description="UTC timestamp of the stats snapshot when available."
+    )
+
+
+class DriveStatsResponse(BaseModel):
+    """Drive level statistics response."""
+
+    drive_label: str = Field(..., description="Drive label referenced by the stats.")
+    totals: StatsTotals = Field(..., description="Totals and category breakdown.")
+
+
+
+class FeatureMetadata(BaseModel):
+    """Metadata row describing a lightweight feature vector entry."""
+
+    path: str = Field(..., description="Inventory path associated with the vector.")
+    kind: str = Field(..., description="Feature kind: image or video.")
+    dim: int = Field(..., description="Vector dimensionality.")
+    frames_used: int = Field(..., description="Number of frames averaged to build the vector.")
+    updated_utc: str = Field(..., description="Last update timestamp in UTC (ISO8601).")
+
+
+class FeaturesResponse(PaginatedResponse):
+    """Paginated listing of lightweight feature metadata."""
+
+    results: List[FeatureMetadata] = Field(..., description="Feature metadata rows for this page.")
+
+
+class FeatureVectorResponse(BaseModel):
+    """Single feature vector payload."""
+
+    path: str = Field(..., description="Inventory path associated with the vector.")
+    dim: int = Field(..., description="Vector dimensionality.")
+    kind: Optional[str] = Field(None, description="Feature kind if available.")
+    vector: List[float] = Field(..., description="Float32 vector serialised as JSON array.")
+
+
+class DrivesResponse(BaseModel):
+    """Wrapper around drive list payload."""
+
+    results: List[DriveInfo] = Field(..., description="Known drive entries in the catalog.")

--- a/api/server.py
+++ b/api/server.py
@@ -1,0 +1,220 @@
+"""FastAPI application exposing a read-only REST interface over the catalog."""
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import List, Optional, Sequence
+
+from fastapi import Depends, FastAPI, HTTPException, Query, Request, status
+from fastapi.exceptions import RequestValidationError
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+
+from .auth import APIKeyAuth
+from .db import DataAccess
+from .models import (
+    DriveStatsResponse,
+    DrivesResponse,
+    FeatureVectorResponse,
+    FeaturesResponse,
+    FileResponse,
+    HealthResponse,
+    InventoryResponse,
+)
+
+LOGGER = logging.getLogger("videocatalog.api")
+
+
+@dataclass(slots=True)
+class APIServerConfig:
+    """Runtime configuration for the FastAPI application."""
+
+    data_access: DataAccess
+    api_key: Optional[str]
+    cors_origins: Sequence[str]
+    app_version: str = "dev"
+    vector_inline_dim: int = 2048
+
+
+def create_app(config: APIServerConfig) -> FastAPI:
+    """Create a FastAPI application bound to the given configuration."""
+
+    app = FastAPI(
+        title="VideoCatalog Local API",
+        version=config.app_version,
+        docs_url="/docs",
+        openapi_url="/openapi.json",
+    )
+
+    allowed_origins: List[str] = [origin for origin in config.cors_origins if origin]
+    if allowed_origins:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=allowed_origins,
+            allow_methods=["GET"],
+            allow_headers=["*"],
+        )
+
+    auth_dependency = APIKeyAuth(config.api_key)
+    data = config.data_access
+
+    @app.middleware("http")
+    async def log_requests(request: Request, call_next):  # type: ignore[override]
+        start = time.perf_counter()
+        response = None
+        try:
+            response = await call_next(request)
+            return response
+        finally:
+            duration_ms = (time.perf_counter() - start) * 1000
+            status_code = response.status_code if response is not None else 500
+            client = request.client.host if request.client else "-"
+            LOGGER.info(
+                "%s %s -> %s (%.1f ms) ip=%s",
+                request.method,
+                request.url.path,
+                status_code,
+                duration_ms,
+                client,
+            )
+
+    @app.exception_handler(HTTPException)
+    async def http_exception_handler(_request: Request, exc: HTTPException):
+        detail = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
+        return JSONResponse(status_code=exc.status_code, content={"error": detail})
+
+    @app.exception_handler(RequestValidationError)
+    async def validation_exception_handler(_request: Request, exc: RequestValidationError):
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content={"error": "invalid parameters", "details": exc.errors()},
+        )
+
+    def ensure_drive(drive_label: str) -> None:
+        try:
+            data._shard_path_for(drive_label)  # type: ignore[attr-defined]
+        except FileNotFoundError:
+            raise HTTPException(status_code=404, detail="unknown drive_label")
+        except LookupError:
+            raise HTTPException(status_code=404, detail="unknown drive_label")
+
+    @app.get("/v1/health", response_model=HealthResponse)
+    def health_check(_: str = Depends(auth_dependency)) -> HealthResponse:
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        return HealthResponse(ok=True, version=config.app_version, time_utc=now)
+
+    @app.get("/v1/drives", response_model=DrivesResponse)
+    def drives(_: str = Depends(auth_dependency)) -> DrivesResponse:
+        results = data.list_drives()
+        return DrivesResponse(results=results)
+
+    @app.get("/v1/inventory", response_model=InventoryResponse)
+    def inventory(
+        drive_label: str = Query(..., description="Drive label to query."),
+        q: Optional[str] = Query(None, description="Substring filter across name/path."),
+        category: Optional[str] = Query(None, description="Filter by category."),
+        ext: Optional[str] = Query(None, description="Filter by extension."),
+        mime: Optional[str] = Query(None, description="Filter by MIME prefix."),
+        since: Optional[str] = Query(None, description="Return rows with mtime >= this ISO timestamp."),
+        limit: Optional[int] = Query(None, ge=1),
+        offset: Optional[int] = Query(None, ge=0),
+        _: str = Depends(auth_dependency),
+    ) -> InventoryResponse:
+        ensure_drive(drive_label)
+        try:
+            results, pagination, next_offset, total = data.inventory_page(
+                drive_label,
+                q=q,
+                category=category,
+                ext=ext,
+                mime=mime,
+                since=since,
+                limit=limit,
+                offset=offset,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return InventoryResponse(
+            results=results,
+            limit=pagination.limit,
+            offset=pagination.offset,
+            next_offset=next_offset,
+            total_estimate=total,
+        )
+
+    @app.get("/v1/file", response_model=FileResponse)
+    def file_details(
+        drive_label: str = Query(..., description="Drive label to query."),
+        path: str = Query(..., description="Exact inventory path."),
+        _: str = Depends(auth_dependency),
+    ) -> FileResponse:
+        ensure_drive(drive_label)
+        row = data.inventory_row(drive_label, path)
+        if row is None:
+            raise HTTPException(status_code=404, detail="file not found")
+        return FileResponse(**row)
+
+    @app.get("/v1/stats", response_model=DriveStatsResponse)
+    def stats(
+        drive_label: str = Query(..., description="Drive label to query."),
+        _: str = Depends(auth_dependency),
+    ) -> DriveStatsResponse:
+        ensure_drive(drive_label)
+        payload = data.drive_stats(drive_label)
+        return DriveStatsResponse(**payload)
+
+    @app.get("/v1/features", response_model=FeaturesResponse)
+    def features(
+        drive_label: str = Query(..., description="Drive label to query."),
+        path: Optional[str] = Query(None, description="Substring filter on path."),
+        kind: Optional[str] = Query(None, description="Feature kind (image/video)."),
+        limit: Optional[int] = Query(None, ge=1),
+        offset: Optional[int] = Query(None, ge=0),
+        _: str = Depends(auth_dependency),
+    ) -> FeaturesResponse:
+        ensure_drive(drive_label)
+        results, pagination, next_offset, total = data.features_page(
+            drive_label,
+            path_query=path,
+            kind=kind,
+            limit=limit,
+            offset=offset,
+        )
+        return FeaturesResponse(
+            results=results,
+            limit=pagination.limit,
+            offset=pagination.offset,
+            next_offset=next_offset,
+            total_estimate=total,
+        )
+
+    @app.get("/v1/features/vector", response_model=FeatureVectorResponse)
+    def feature_vector(
+        drive_label: str = Query(..., description="Drive label to query."),
+        path: str = Query(..., description="Exact inventory path."),
+        raw: bool = Query(False, description="Set to true to allow large vectors."),
+        _: str = Depends(auth_dependency),
+    ) -> FeatureVectorResponse:
+        ensure_drive(drive_label)
+        row = data.feature_vector(drive_label, path)
+        if row is None:
+            raise HTTPException(status_code=404, detail="feature not found")
+        if not raw and row.get("dim", 0) > config.vector_inline_dim:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "vector dimensionality exceeds inline guard; "
+                    "retry with raw=true if you intend to download"
+                ),
+            )
+        return FeatureVectorResponse(**row)
+
+    return app
+
+
+__all__ = [
+    "APIServerConfig",
+    "create_app",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ numpy
 Pillow
 onnxruntime
 opencv-python-headless
+fastapi
+uvicorn

--- a/settings.json
+++ b/settings.json
@@ -5,5 +5,17 @@
     "model_path": null,
     "max_video_frames": 2,
     "prefer_ffmpeg": true
+  },
+  "api": {
+    "enabled_default": false,
+    "host": "127.0.0.1",
+    "port": 8756,
+    "api_key": null,
+    "cors_origins": [
+      "http://localhost",
+      "http://127.0.0.1"
+    ],
+    "default_limit": 100,
+    "max_page_size": 500
   }
 }

--- a/videocatalog_api.py
+++ b/videocatalog_api.py
@@ -1,0 +1,90 @@
+"""CLI entry-point to launch the VideoCatalog read-only HTTP API."""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+import uvicorn
+
+from api import __version__ as API_VERSION
+from api.db import DataAccess
+from api.server import APIServerConfig, create_app
+from paths import load_settings, resolve_working_dir
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8756
+DEFAULT_CORS = ["http://localhost", "http://127.0.0.1"]
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Start the local VideoCatalog API service.")
+    parser.add_argument("--host", default=None, help="Bind host (default from settings.json)")
+    parser.add_argument("--port", type=int, default=None, help="Bind port (default from settings.json)")
+    parser.add_argument("--api-key", dest="api_key", default=None, help="Override the API key for this session")
+    parser.add_argument(
+        "--cors",
+        action="append",
+        dest="cors",
+        default=None,
+        help="Additional allowed CORS origin (repeatable).",
+    )
+    return parser.parse_args(argv)
+
+
+def resolve_api_settings(args: argparse.Namespace) -> tuple[str, int, Optional[str], List[str], DataAccess]:
+    working_dir = resolve_working_dir()
+    settings = load_settings(working_dir)
+    api_settings = settings.get("api") if isinstance(settings.get("api"), dict) else {}
+
+    host = args.host or api_settings.get("host") or DEFAULT_HOST
+    port = args.port or api_settings.get("port") or DEFAULT_PORT
+    try:
+        port = int(port)
+    except (TypeError, ValueError):
+        port = DEFAULT_PORT
+
+    api_key = args.api_key if args.api_key else api_settings.get("api_key")
+
+    if args.cors:
+        cors = list(args.cors)
+    else:
+        cors = list(api_settings.get("cors_origins") or DEFAULT_CORS)
+
+    data_access = DataAccess(working_dir=Path(working_dir), settings=settings)
+    return str(host), int(port), api_key, cors, data_access
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+    args = parse_args(argv)
+    host, port, api_key, cors, data_access = resolve_api_settings(args)
+
+    if not api_key:
+        logging.warning("API key is not configured; all requests will be rejected with 401.")
+
+    config = APIServerConfig(
+        data_access=data_access,
+        api_key=api_key,
+        cors_origins=cors,
+        app_version=API_VERSION,
+    )
+    app = create_app(config)
+
+    print(f"API listening on http://{host}:{port}", flush=True)
+
+    uvicorn_config = uvicorn.Config(
+        app,
+        host=host,
+        port=port,
+        log_level="info",
+        access_log=False,
+    )
+    server = uvicorn.Server(uvicorn_config)
+    return 0 if server.run() else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a read-only FastAPI service under `api/` with paginated inventory, stats, and feature endpoints secured by an API key
- introduce `videocatalog_api.py` CLI and a GUI toggle to start/stop the local API without blocking the UI
- document the API workflow, extend settings defaults, and add FastAPI/uvicorn dependencies

## Testing
- python -m compileall api DiskScannerGUI.py videocatalog_api.py

------
https://chatgpt.com/codex/tasks/task_e_68e6fe93d5488327a786c8e1c9d5e28b