### PR TITLE
Add fingerprint pipeline with TMK and Chromaprint

### DIFF
--- a/fingerprints/__init__.py
+++ b/fingerprints/__init__.py
@@ -1,0 +1,12 @@
+"""Fingerprint helpers for VideoCatalog."""
+
+from . import tools, store, video_tmk, audio_chroma, video_vhash, match
+
+__all__ = [
+    "tools",
+    "store",
+    "video_tmk",
+    "audio_chroma",
+    "video_vhash",
+    "match",
+]

--- a/fingerprints/audio_chroma.py
+++ b/fingerprints/audio_chroma.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from .tools import ChromaprintTool, resolve_chromaprint
+
+
+@dataclass(slots=True)
+class ChromaprintFingerprint:
+    path: Path
+    duration_seconds: Optional[float]
+    fingerprint: str
+    tool_version: Optional[str]
+
+
+class ChromaprintError(RuntimeError):
+    pass
+
+
+class ChromaprintGenerator:
+    def __init__(self, tool: Optional[ChromaprintTool]) -> None:
+        self._tool = tool or resolve_chromaprint()
+
+    @property
+    def available(self) -> bool:
+        return self._tool is not None
+
+    @property
+    def executable(self) -> Optional[str]:
+        return self._tool.executable if self._tool else None
+
+    def compute(self, source: Path, timeout: int = 900) -> Optional[ChromaprintFingerprint]:
+        if not self._tool:
+            return None
+        cmd = [self._tool.executable, "-json", str(source)]
+        try:
+            completed = subprocess.run(
+                cmd,
+                capture_output=True,
+                check=False,
+                text=True,
+                timeout=timeout,
+            )
+        except FileNotFoundError as exc:
+            raise ChromaprintError(str(exc)) from exc
+        except subprocess.TimeoutExpired as exc:  # pragma: no cover - defensive
+            raise ChromaprintError(f"fpcalc timed out after {timeout}s") from exc
+        if completed.returncode != 0 or not completed.stdout.strip():
+            raise ChromaprintError(
+                completed.stderr.strip() or completed.stdout.strip() or "fpcalc failed"
+            )
+        payload = json.loads(completed.stdout)
+        fingerprint = str(payload.get("fingerprint") or "").strip()
+        if not fingerprint:
+            raise ChromaprintError("fpcalc did not return a fingerprint")
+        duration = payload.get("duration")
+        try:
+            duration_value = float(duration) if duration is not None else None
+        except (TypeError, ValueError):
+            duration_value = None
+        return ChromaprintFingerprint(
+            path=source,
+            duration_seconds=duration_value,
+            fingerprint=fingerprint,
+            tool_version=self._tool.version,
+        )

--- a/fingerprints/match.py
+++ b/fingerprints/match.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import itertools
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, Iterator, List, Optional, Sequence, Tuple
+
+from .audio_chroma import ChromaprintGenerator
+from .store import FingerprintStore
+from .video_tmk import TMKVideoFingerprinter
+from .video_vhash import normalized_similarity
+
+
+@dataclass(slots=True)
+class MatchOptions:
+    use_video: bool = True
+    use_audio: bool = False
+    use_consensus: bool = False
+    tmk_threshold: float = 0.75
+    chroma_threshold: float = 0.15
+    consensus_video_weight: float = 0.7
+    use_prefilter: bool = True
+
+
+class MatchProgress:
+    def __init__(self, callback: Optional[Callable[[dict], None]]) -> None:
+        self._callback = callback
+
+    def emit(self, phase: str, **payload: object) -> None:
+        if not self._callback:
+            return
+        message = {"type": "fingerprint_match", "phase": phase}
+        message.update(payload)
+        try:
+            self._callback(message)
+        except Exception:
+            pass
+
+
+def find_probable_duplicates(
+    store: FingerprintStore,
+    *,
+    options: MatchOptions,
+    fingerprinter: Optional[TMKVideoFingerprinter] = None,
+    chromaprint: Optional[ChromaprintGenerator] = None,
+    progress_callback: Optional[Callable[[dict], None]] = None,
+) -> List[Tuple[str, str, float, str]]:
+    progress = MatchProgress(progress_callback)
+    fingerprinter = fingerprinter or TMKVideoFingerprinter(None)
+    chromaprint = chromaprint or ChromaprintGenerator(None)
+
+    video_pairs = _collect_video_pairs(store, options.use_prefilter)
+    audio_pairs = _collect_audio_pairs(store)
+
+    matches: Dict[Tuple[str, str], Dict[str, float]] = {}
+    results: List[Tuple[str, str, float, str]] = []
+
+    if options.use_video and fingerprinter.available:
+        progress.emit("video", total=len(video_pairs))
+        for idx, (a, b, sig_a, sig_b) in enumerate(video_pairs, start=1):
+            try:
+                score = fingerprinter.similarity(sig_a, sig_b)
+            except Exception:
+                continue
+            if score >= options.tmk_threshold:
+                key = _pair_key(a, b)
+                matches.setdefault(key, {})["video"] = score
+                results.append((key[0], key[1], score, "video"))
+                store.store_candidate(key[0], key[1], score, "video")
+            if idx % 25 == 0:
+                progress.emit("video", processed=idx, total=len(video_pairs))
+        progress.emit("video", processed=len(video_pairs), total=len(video_pairs))
+
+    if options.use_audio:
+        progress.emit("audio", total=len(audio_pairs))
+        for idx, (a, b, fp_a, fp_b) in enumerate(audio_pairs, start=1):
+            distance = chroma_distance(fp_a, fp_b)
+            if distance <= options.chroma_threshold:
+                score = 1.0 - distance
+                key = _pair_key(a, b)
+                matches.setdefault(key, {})["audio"] = score
+                results.append((key[0], key[1], score, "audio"))
+                store.store_candidate(key[0], key[1], score, "audio")
+            if idx % 100 == 0:
+                progress.emit("audio", processed=idx, total=len(audio_pairs))
+        progress.emit("audio", processed=len(audio_pairs), total=len(audio_pairs))
+
+    if options.use_consensus:
+        for key, parts in matches.items():
+            if "video" not in parts or "audio" not in parts:
+                continue
+            video_score = parts.get("video", 0.0)
+            audio_score = parts.get("audio", 0.0)
+            consensus = (
+                options.consensus_video_weight * video_score
+                + (1.0 - options.consensus_video_weight) * audio_score
+            )
+            results.append((key[0], key[1], consensus, "consensus"))
+            store.store_candidate(key[0], key[1], consensus, "consensus")
+    return results
+
+
+def _collect_video_pairs(
+    store: FingerprintStore, use_prefilter: bool
+) -> List[Tuple[str, str, bytes, bytes]]:
+    signatures = list(store.iter_video_signatures())
+    vhash_map = store.fetch_vhashes() if use_prefilter else {}
+    pairs: List[Tuple[str, str, bytes, bytes]] = []
+    for (path_a, sig_a, _), (path_b, sig_b, _) in itertools.combinations(signatures, 2):
+        if use_prefilter and path_a in vhash_map and path_b in vhash_map:
+            similarity = normalized_similarity(vhash_map[path_a], vhash_map[path_b])
+            if similarity < 0.75:
+                continue
+        pairs.append((path_a, path_b, sig_a, sig_b))
+    return pairs
+
+
+def _collect_audio_pairs(store: FingerprintStore) -> List[Tuple[str, str, str, str]]:
+    fingerprints = list(store.iter_audio_fingerprints())
+    pairs: List[Tuple[str, str, str, str]] = []
+    for (path_a, fp_a, _), (path_b, fp_b, _) in itertools.combinations(fingerprints, 2):
+        pairs.append((path_a, path_b, fp_a, fp_b))
+    return pairs
+
+
+def chroma_distance(fp_a: str, fp_b: str) -> float:
+    seq_a = _parse_chromaprint(fp_a)
+    seq_b = _parse_chromaprint(fp_b)
+    if not seq_a or not seq_b:
+        return 1.0
+    length = min(len(seq_a), len(seq_b))
+    if length == 0:
+        return 1.0
+    mismatches = sum(1 for idx in range(length) if seq_a[idx] != seq_b[idx])
+    return mismatches / float(length)
+
+
+def _parse_chromaprint(raw: str) -> List[int]:
+    values: List[int] = []
+    for token in raw.replace("|", " ").replace(",", " ").split():
+        try:
+            values.append(int(token))
+        except ValueError:
+            continue
+    return values
+
+
+def _pair_key(a: str, b: str) -> Tuple[str, str]:
+    return (a, b) if a <= b else (b, a)

--- a/fingerprints/store.py
+++ b/fingerprints/store.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Iterator, Optional, Tuple
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS video_fp_tmk (
+    path TEXT PRIMARY KEY,
+    tmk_version TEXT,
+    duration_seconds REAL,
+    sig_bytes BLOB NOT NULL,
+    updated_utc TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_video_fp_updated ON video_fp_tmk(updated_utc);
+
+CREATE TABLE IF NOT EXISTS audio_fp_chroma (
+    path TEXT PRIMARY KEY,
+    chroma_version TEXT,
+    duration_seconds REAL,
+    fp TEXT NOT NULL,
+    updated_utc TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_audio_fp_updated ON audio_fp_chroma(updated_utc);
+
+CREATE TABLE IF NOT EXISTS video_vhash (
+    path TEXT PRIMARY KEY,
+    vhash64 TEXT NOT NULL,
+    updated_utc TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS duplicate_candidates (
+    path_a TEXT NOT NULL,
+    path_b TEXT NOT NULL,
+    score REAL NOT NULL,
+    reason TEXT NOT NULL,
+    created_utc TEXT NOT NULL,
+    PRIMARY KEY(path_a, path_b, reason)
+);
+"""
+
+
+def ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(SCHEMA)
+
+
+class FingerprintStore:
+    def __init__(self, db_path: Path | str, *, timeout: float = 30.0) -> None:
+        self._path = Path(db_path)
+        self._conn = sqlite3.connect(
+            str(self._path), timeout=timeout, check_same_thread=False
+        )
+        ensure_schema(self._conn)
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.commit()
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    @property
+    def connection(self) -> sqlite3.Connection:
+        return self._conn
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def upsert_video_signature(
+        self,
+        *,
+        path: str,
+        duration: Optional[float],
+        signature: bytes,
+        version: Optional[str],
+    ) -> None:
+        now = _utc_now()
+        self._conn.execute(
+            """
+            INSERT INTO video_fp_tmk(path, tmk_version, duration_seconds, sig_bytes, updated_utc)
+            VALUES(?,?,?,?,?)
+            ON CONFLICT(path) DO UPDATE SET
+                tmk_version=excluded.tmk_version,
+                duration_seconds=excluded.duration_seconds,
+                sig_bytes=excluded.sig_bytes,
+                updated_utc=excluded.updated_utc
+            """,
+            (path, version, duration, sqlite3.Binary(signature), now),
+        )
+        self._conn.commit()
+
+    def upsert_audio_signature(
+        self,
+        *,
+        path: str,
+        duration: Optional[float],
+        fingerprint: str,
+        version: Optional[str],
+    ) -> None:
+        now = _utc_now()
+        self._conn.execute(
+            """
+            INSERT INTO audio_fp_chroma(path, chroma_version, duration_seconds, fp, updated_utc)
+            VALUES(?,?,?,?,?)
+            ON CONFLICT(path) DO UPDATE SET
+                chroma_version=excluded.chroma_version,
+                duration_seconds=excluded.duration_seconds,
+                fp=excluded.fp,
+                updated_utc=excluded.updated_utc
+            """,
+            (path, version, duration, fingerprint, now),
+        )
+        self._conn.commit()
+
+    def upsert_video_vhash(self, *, path: str, vhash: str) -> None:
+        now = _utc_now()
+        self._conn.execute(
+            """
+            INSERT INTO video_vhash(path, vhash64, updated_utc)
+            VALUES(?,?,?)
+            ON CONFLICT(path) DO UPDATE SET
+                vhash64=excluded.vhash64,
+                updated_utc=excluded.updated_utc
+            """,
+            (path, vhash, now),
+        )
+        self._conn.commit()
+
+    def has_video_signature(self, path: str) -> bool:
+        cur = self._conn.execute(
+            "SELECT 1 FROM video_fp_tmk WHERE path=?", (path,)
+        )
+        return cur.fetchone() is not None
+
+    def has_audio_signature(self, path: str) -> bool:
+        cur = self._conn.execute(
+            "SELECT 1 FROM audio_fp_chroma WHERE path=?", (path,)
+        )
+        return cur.fetchone() is not None
+
+    def has_vhash(self, path: str) -> bool:
+        cur = self._conn.execute("SELECT 1 FROM video_vhash WHERE path=?", (path,))
+        return cur.fetchone() is not None
+
+    def store_candidate(self, path_a: str, path_b: str, score: float, reason: str) -> None:
+        if path_a == path_b:
+            return
+        if path_b < path_a:
+            path_a, path_b = path_b, path_a
+        now = _utc_now()
+        self._conn.execute(
+            """
+            INSERT INTO duplicate_candidates(path_a, path_b, score, reason, created_utc)
+            VALUES(?,?,?,?,?)
+            ON CONFLICT(path_a, path_b, reason) DO UPDATE SET
+                score=max(score, excluded.score),
+                created_utc=excluded.created_utc
+            """,
+            (path_a, path_b, float(score), reason, now),
+        )
+        self._conn.commit()
+
+    def iter_video_signatures(self) -> Iterator[Tuple[str, bytes, Optional[float]]]:
+        cur = self._conn.execute(
+            "SELECT path, sig_bytes, duration_seconds FROM video_fp_tmk"
+        )
+        for path, blob, duration in cur.fetchall():
+            yield path, blob, duration
+
+    def iter_audio_fingerprints(self) -> Iterator[Tuple[str, str, Optional[float]]]:
+        cur = self._conn.execute(
+            "SELECT path, fp, duration_seconds FROM audio_fp_chroma"
+        )
+        for path, fp, duration in cur.fetchall():
+            yield path, fp, duration
+
+    def fetch_vhashes(self) -> dict[str, str]:
+        cur = self._conn.execute("SELECT path, vhash64 FROM video_vhash")
+        return {row[0]: row[1] for row in cur.fetchall()}
+
+
+def _utc_now() -> str:
+    return datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/fingerprints/tools.py
+++ b/fingerprints/tools.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass(slots=True)
+class TMKToolchain:
+    """Paths to the TMK+PDQF helpers."""
+
+    hash_tool: str
+    compare_tool: str
+    extractor_tool: Optional[str]
+    version: Optional[str]
+
+
+@dataclass(slots=True)
+class ChromaprintTool:
+    """Metadata about the Chromaprint fpcalc utility."""
+
+    executable: str
+    version: Optional[str]
+
+
+class ToolDiscoveryError(RuntimeError):
+    """Raised when a required external helper cannot be located."""
+
+
+def _executable_name(base: str) -> str:
+    if platform.system().lower().startswith("win"):
+        return f"{base}.exe"
+    return base
+
+
+def _which_with_override(name: str, override: Optional[str]) -> Optional[str]:
+    if override:
+        candidate = Path(os.path.expandvars(os.path.expanduser(override)))
+        if candidate.is_dir():
+            exe = candidate / _executable_name(name)
+            if exe.exists():
+                return str(exe.resolve())
+        elif candidate.exists():
+            return str(candidate.resolve())
+    path = shutil.which(name)
+    return path
+
+
+def resolve_tmk_toolchain(override: Optional[str] = None) -> Optional[TMKToolchain]:
+    """Locate the TMK+PDQF helper binaries."""
+
+    hash_path = _which_with_override("tmk-hash-video", override)
+    compare_path = _which_with_override("tmk-compare-post", override)
+    extractor_path = _which_with_override("tmk-extract-frame", override)
+
+    if not hash_path or not compare_path:
+        return None
+
+    version = _probe_version([hash_path, "--version"]) or _probe_version(
+        [compare_path, "--version"]
+    )
+    return TMKToolchain(
+        hash_tool=hash_path,
+        compare_tool=compare_path,
+        extractor_tool=extractor_path,
+        version=version,
+    )
+
+
+def resolve_chromaprint(override: Optional[str] = None) -> Optional[ChromaprintTool]:
+    exe = _which_with_override("fpcalc", override)
+    if not exe:
+        return None
+    version = _probe_version([exe, "-version"]) or _probe_version([exe, "--version"])
+    return ChromaprintTool(executable=exe, version=version)
+
+
+def have_videohash() -> bool:
+    try:
+        import importlib
+
+        importlib.import_module("videohash")
+        return True
+    except ModuleNotFoundError:
+        return False
+    except Exception:
+        return False
+
+
+def _probe_version(cmd: list[str]) -> Optional[str]:
+    try:
+        completed = subprocess.run(
+            cmd,
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+    except OSError:
+        return None
+    if completed.returncode != 0:
+        output = completed.stdout or completed.stderr or ""
+    else:
+        output = completed.stdout or completed.stderr or ""
+    output = output.strip()
+    if not output:
+        return None
+    first_line = output.splitlines()[0]
+    return first_line.strip()
+
+
+def ensure_executable_present(name: str, override: Optional[str] = None) -> str:
+    path = _which_with_override(name, override)
+    if not path:
+        raise ToolDiscoveryError(f"Unable to locate executable: {name}")
+    return path

--- a/fingerprints/video_tmk.py
+++ b/fingerprints/video_tmk.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from .tools import TMKToolchain, resolve_tmk_toolchain
+
+
+@dataclass(slots=True)
+class TMKSignature:
+    path: Path
+    duration_seconds: Optional[float]
+    signature: bytes
+    tool_version: Optional[str]
+
+
+class TMKVideoError(RuntimeError):
+    pass
+
+
+class TMKVideoFingerprinter:
+    def __init__(self, toolchain: Optional[TMKToolchain]) -> None:
+        self._toolchain = toolchain or resolve_tmk_toolchain()
+
+    @property
+    def available(self) -> bool:
+        return self._toolchain is not None
+
+    def compute(
+        self,
+        source: Path,
+        *,
+        duration_hint: Optional[float] = None,
+        timeout: int = 1800,
+    ) -> Optional[TMKSignature]:
+        if not self._toolchain:
+            return None
+        with tempfile.TemporaryDirectory(prefix="tmk_sig_") as tmpdir:
+            sig_path = Path(tmpdir) / "signature.tmk"
+            json_path = Path(tmpdir) / "signature.json"
+            base_cmd = [
+                self._toolchain.hash_tool,
+                "-i",
+                str(source),
+                "-o",
+                str(sig_path),
+            ]
+            if self._toolchain.extractor_tool:
+                base_cmd.extend(["--pdq-path", self._toolchain.extractor_tool])
+
+            def _invoke(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+                try:
+                    return subprocess.run(
+                        cmd,
+                        capture_output=True,
+                        check=False,
+                        text=True,
+                        timeout=timeout,
+                    )
+                except FileNotFoundError as exc:
+                    raise TMKVideoError(str(exc)) from exc
+                except subprocess.TimeoutExpired as exc:
+                    raise TMKVideoError(
+                        f"tmk-hash-video timed out after {timeout}s"
+                    ) from exc
+
+            cmd = base_cmd + ["--json", str(json_path)]
+            completed = _invoke(cmd)
+            if completed.returncode != 0:
+                stderr = (completed.stderr or "").strip()
+                stdout = (completed.stdout or "").strip()
+                if "unrecognized" in stderr.lower() or "unknown option" in stderr.lower():
+                    completed = _invoke(base_cmd)
+                else:
+                    raise TMKVideoError(stderr or stdout or "tmk-hash-video failed")
+            if completed.returncode != 0:
+                stderr = (completed.stderr or "").strip()
+                stdout = (completed.stdout or "").strip()
+                raise TMKVideoError(stderr or stdout or "tmk-hash-video failed")
+            if not sig_path.exists():
+                raise TMKVideoError("tmk-hash-video did not create a signature")
+            signature_bytes = sig_path.read_bytes()
+            duration_value = duration_hint
+            if json_path.exists():
+                try:
+                    payload = json.loads(json_path.read_text())
+                    duration_value = float(payload.get("duration"))
+                except Exception:
+                    pass
+            return TMKSignature(
+                path=source,
+                duration_seconds=duration_value,
+                signature=signature_bytes,
+                tool_version=self._toolchain.version,
+            )
+
+    def similarity(self, sig_a: bytes, sig_b: bytes, timeout: int = 600) -> float:
+        if not self._toolchain:
+            raise TMKVideoError("TMK toolchain not available")
+        with tempfile.TemporaryDirectory(prefix="tmk_cmp_") as tmpdir:
+            file_a = Path(tmpdir) / "a.tmk"
+            file_b = Path(tmpdir) / "b.tmk"
+            file_a.write_bytes(sig_a)
+            file_b.write_bytes(sig_b)
+            cmd = [
+                self._toolchain.compare_tool,
+                str(file_a),
+                str(file_b),
+            ]
+            try:
+                completed = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    check=False,
+                    text=True,
+                    timeout=timeout,
+                )
+            except FileNotFoundError as exc:
+                raise TMKVideoError(str(exc)) from exc
+            except subprocess.TimeoutExpired as exc:
+                raise TMKVideoError(f"tmk-compare-post timed out after {timeout}s") from exc
+            output = completed.stdout or completed.stderr or ""
+            if completed.returncode != 0:
+                raise TMKVideoError(output.strip() or "tmk-compare-post failed")
+            return _parse_similarity(output)
+
+
+def _parse_similarity(output: str) -> float:
+    text = output.strip()
+    if not text:
+        return 0.0
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            return float(stripped.split()[-1])
+        except (ValueError, IndexError):
+            continue
+    try:
+        return float(text)
+    except ValueError:
+        return 0.0

--- a/fingerprints/video_vhash.py
+++ b/fingerprints/video_vhash.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from .tools import have_videohash
+
+
+@dataclass(slots=True)
+class VideoVHash:
+    path: Path
+    hash64: str
+
+
+class VideoVHashError(RuntimeError):
+    pass
+
+
+def compute_vhash(source: Path) -> Optional[VideoVHash]:
+    if not have_videohash():
+        return None
+    try:
+        from videohash import VideoHash  # type: ignore
+    except Exception as exc:  # pragma: no cover - dynamic import guard
+        raise VideoVHashError(str(exc)) from exc
+
+    try:
+        vh = VideoHash(str(source), hash_size=16)
+    except Exception as exc:  # pragma: no cover - underlying library errors
+        raise VideoVHashError(str(exc)) from exc
+    digest = getattr(vh, "videohash", None)
+    if not digest:
+        return None
+    return VideoVHash(path=source, hash64=str(digest))
+
+
+def hamming_distance(hash_a: str, hash_b: str) -> int:
+    bytes_a = _to_bytes(hash_a)
+    bytes_b = _to_bytes(hash_b)
+    if len(bytes_a) != len(bytes_b):
+        raise ValueError("Hashes must have identical length for Hamming distance")
+    distance = 0
+    for ba, bb in zip(bytes_a, bytes_b):
+        distance += bin(ba ^ bb).count("1")
+    return distance
+
+
+def normalized_similarity(hash_a: str, hash_b: str) -> float:
+    bytes_a = _to_bytes(hash_a)
+    bytes_b = _to_bytes(hash_b)
+    distance = hamming_distance(hash_a, hash_b)
+    max_bits = len(bytes_a) * 8
+    if max_bits == 0:
+        return 0.0
+    return max(0.0, 1.0 - (distance / max_bits))
+
+
+def _to_bytes(value: str) -> bytes:
+    cleaned = value.strip()
+    try:
+        return bytes.fromhex(cleaned)
+    except ValueError:
+        return cleaned.encode("utf-8")

--- a/settings.json
+++ b/settings.json
@@ -6,6 +6,18 @@
     "max_video_frames": 2,
     "prefer_ffmpeg": true
   },
+  "fingerprints": {
+    "enable_video_tmk": false,
+    "enable_audio_chroma": false,
+    "enable_video_vhash_prefilter": true,
+    "max_concurrency": 2,
+    "io_gentle_ms": 2,
+    "phase_mode": "off",
+    "tmk_bin_path": null,
+    "fpcalc_path": null,
+    "tmk_similarity_threshold": 0.75,
+    "chroma_match_threshold": 0.15
+  },
   "api": {
     "enabled_default": false,
     "host": "127.0.0.1",


### PR DESCRIPTION
## Summary
- integrate TMK+PDQF, Chromaprint, and videohash helpers under a new fingerprints/ package with SQLite persistence and matching scaffolding
- wire the scanner to schedule fingerprint jobs with configurable phase, workers, and CLI flags, surfacing summaries in the scan results
- extend defaults and documentation to describe the duplicate-detection workflow and configuration options

## Testing
- python -m compileall fingerprints scan_drive.py

------
https://chatgpt.com/codex/tasks/task_e_68e71cb76b4883279cbb40c7a2410bf7