### PR TITLE
Add semantic indexing pipeline, CLI flags, and API endpoints

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -46,6 +46,64 @@ class PaginatedResponse(BaseModel):
 
 
 
+class SemanticSearchHit(BaseModel):
+    """Single semantic search hit."""
+
+    rank: int = Field(..., description="Rank within the current page starting at 1.")
+    path: str = Field(..., description="Inventory path returned by the semantic engine.")
+    drive_label: str = Field(..., description="Drive label owning this path.")
+    score: float = Field(..., description="Combined similarity score (0..1).")
+    mode: str = Field(..., description="Search mode used for this hit (ann/text/hybrid).")
+    snippet: Optional[str] = Field(
+        None, description="Optional snippet produced by the FTS query when available."
+    )
+    metadata: Dict[str, object] = Field(
+        default_factory=dict,
+        description="Additional metadata captured in the semantic index.",
+    )
+
+
+class SemanticSearchResponse(PaginatedResponse):
+    """Paginated semantic search payload."""
+
+    query: str = Field(..., description="Original query string that was executed.")
+    mode: str = Field(..., description="Mode requested: ann, text, or hybrid.")
+    hybrid: bool = Field(..., description="True when hybrid scoring blended ANN and FTS results.")
+    results: List[SemanticSearchHit] = Field(
+        ..., description="Semantic search hits ordered by descending score."
+    )
+
+
+class SemanticIndexRequest(BaseModel):
+    """Request body for semantic index operations."""
+
+    mode: str = Field(
+        "build",
+        description="Operation to execute: build (incremental) or rebuild (clear and rebuild).",
+    )
+
+
+class SemanticOperationResponse(BaseModel):
+    """Simple acknowledgement for semantic maintenance operations."""
+
+    ok: bool = Field(True, description="Indicates the operation completed without raising errors.")
+    action: str = Field(..., description="Operation that was performed.")
+    stats: Dict[str, int] = Field(
+        default_factory=dict,
+        description="Optional counters returned by the semantic pipeline.",
+    )
+
+
+class SemanticStatusResponse(BaseModel):
+    """Status summary for the semantic index."""
+
+    documents: int = Field(..., description="Total documents currently stored in the index.")
+    latest_updated_utc: Optional[str] = Field(
+        None, description="Timestamp of the most recently updated entry when available."
+    )
+    vector_dim: int = Field(..., description="Vector dimensionality configured for ANN search.")
+
+
 class InventoryRow(BaseModel):
     """Single file entry coming from a drive inventory shard."""
 

--- a/semantic/__init__.py
+++ b/semantic/__init__.py
@@ -1,0 +1,13 @@
+"""Semantic indexing and search helpers for VideoCatalog."""
+from .config import SemanticConfig, SemanticPhaseError
+from .index import SemanticIndexer, SemanticTranscriber
+from .search import SemanticSearcher, SemanticSearchResult
+
+__all__ = [
+    "SemanticConfig",
+    "SemanticPhaseError",
+    "SemanticIndexer",
+    "SemanticTranscriber",
+    "SemanticSearcher",
+    "SemanticSearchResult",
+]

--- a/semantic/config.py
+++ b/semantic/config.py
@@ -1,0 +1,61 @@
+"""Configuration helpers for the semantic indexing pipeline."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+
+
+class SemanticPhaseError(RuntimeError):
+    """Raised when a semantic pipeline phase is disabled by configuration."""
+
+
+@dataclass(slots=True)
+class SemanticConfig:
+    """Resolved semantic settings derived from ``settings.json``."""
+
+    working_dir: Path
+    vector_dim: int = 64
+    hybrid_weight: float = 0.4
+    index_phase: str = "manual"
+    search_phase: str = "enabled"
+    transcribe_phase: str = "manual"
+    rebuild_chunk: int = 500
+
+    @classmethod
+    def from_settings(cls, working_dir: Path, settings: Dict[str, Any]) -> "SemanticConfig":
+        semantic_settings = settings.get("semantic") if isinstance(settings, dict) else None
+        if not isinstance(semantic_settings, dict):
+            semantic_settings = {}
+        vector_dim = int(semantic_settings.get("vector_dim") or 64)
+        if vector_dim <= 0:
+            vector_dim = 64
+        hybrid_weight = float(semantic_settings.get("hybrid_weight") or 0.4)
+        hybrid_weight = min(1.0, max(0.0, hybrid_weight))
+        index_phase = str(semantic_settings.get("index_phase") or "manual").lower()
+        search_phase = str(semantic_settings.get("search_phase") or "enabled").lower()
+        transcribe_phase = str(semantic_settings.get("transcribe_phase") or "manual").lower()
+        rebuild_chunk = int(semantic_settings.get("rebuild_chunk") or 500)
+        if rebuild_chunk <= 0:
+            rebuild_chunk = 500
+        return cls(
+            working_dir=working_dir,
+            vector_dim=vector_dim,
+            hybrid_weight=hybrid_weight,
+            index_phase=index_phase,
+            search_phase=search_phase,
+            transcribe_phase=transcribe_phase,
+            rebuild_chunk=rebuild_chunk,
+        )
+
+    def require_index_phase(self) -> None:
+        if self.index_phase == "off":
+            raise SemanticPhaseError("semantic indexing is disabled by settings")
+
+    def require_search_phase(self) -> None:
+        if self.search_phase == "off":
+            raise SemanticPhaseError("semantic search is disabled by settings")
+
+    def require_transcribe_phase(self) -> None:
+        if self.transcribe_phase == "off":
+            raise SemanticPhaseError("semantic transcription is disabled by settings")

--- a/semantic/db.py
+++ b/semantic/db.py
@@ -1,0 +1,173 @@
+"""SQLite helpers for semantic indexing state."""
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Dict, Iterable, Iterator, Optional
+
+from core.db import connect
+
+SEMANTIC_DB_FILENAME = "semantic_index.db"
+
+
+def semantic_db_path(working_dir: Path) -> Path:
+    return Path(working_dir) / SEMANTIC_DB_FILENAME
+
+
+@contextmanager
+def semantic_connection(working_dir: Path) -> Iterator[sqlite3.Connection]:
+    path = semantic_db_path(working_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = connect(path, read_only=False, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    ensure_schema(conn)
+    try:
+        yield conn
+    finally:
+        conn.commit()
+        conn.close()
+
+
+def ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS semantic_documents (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            drive_label TEXT NOT NULL,
+            path TEXT NOT NULL,
+            content TEXT NOT NULL,
+            embedding TEXT NOT NULL,
+            dim INTEGER NOT NULL,
+            embedding_norm REAL NOT NULL,
+            kind TEXT,
+            updated_utc TEXT,
+            metadata TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_semantic_documents_path
+        ON semantic_documents(drive_label, path)
+        """
+    )
+    conn.execute(
+        """
+        CREATE VIRTUAL TABLE IF NOT EXISTS semantic_documents_fts
+        USING fts5(content, path UNINDEXED, drive_label UNINDEXED, tokenize = 'unicode61')
+        """
+    )
+
+
+def upsert_document(
+    conn: sqlite3.Connection,
+    *,
+    drive_label: str,
+    path: str,
+    content: str,
+    embedding: Iterable[float],
+    dim: int,
+    embedding_norm: float,
+    kind: Optional[str],
+    updated_utc: Optional[str],
+    metadata: Dict[str, Any],
+) -> int:
+    embedding_json = json.dumps(list(embedding))
+    metadata_json = json.dumps(metadata, ensure_ascii=False)
+    cursor = conn.execute(
+        """
+        SELECT id FROM semantic_documents
+        WHERE drive_label = ? AND path = ?
+        """,
+        (drive_label, path),
+    )
+    row = cursor.fetchone()
+    if row:
+        doc_id = int(row["id"])
+        conn.execute(
+            """
+            UPDATE semantic_documents
+            SET content = ?, embedding = ?, dim = ?, embedding_norm = ?, kind = ?,
+                updated_utc = ?, metadata = ?
+            WHERE id = ?
+            """,
+            (
+                content,
+                embedding_json,
+                dim,
+                embedding_norm,
+                kind,
+                updated_utc,
+                metadata_json,
+                doc_id,
+            ),
+        )
+        conn.execute(
+            "DELETE FROM semantic_documents_fts WHERE rowid = ?",
+            (doc_id,),
+        )
+    else:
+        cursor = conn.execute(
+            """
+            INSERT INTO semantic_documents (
+                drive_label, path, content, embedding, dim, embedding_norm, kind, updated_utc, metadata
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                drive_label,
+                path,
+                content,
+                embedding_json,
+                dim,
+                embedding_norm,
+                kind,
+                updated_utc,
+                metadata_json,
+            ),
+        )
+        doc_id = int(cursor.lastrowid)
+    conn.execute(
+        "INSERT INTO semantic_documents_fts(rowid, content, path, drive_label) VALUES (?, ?, ?, ?)",
+        (doc_id, content, path, drive_label),
+    )
+    return doc_id
+
+
+def delete_all(conn: sqlite3.Connection) -> None:
+    conn.execute("DELETE FROM semantic_documents")
+    conn.execute("DELETE FROM semantic_documents_fts")
+
+
+def iter_documents(conn: sqlite3.Connection, *, drive_label: Optional[str] = None):
+    sql = "SELECT * FROM semantic_documents"
+    params: tuple[Any, ...] = ()
+    if drive_label:
+        sql += " WHERE drive_label = ?"
+        params = (drive_label,)
+    cursor = conn.execute(sql, params)
+    for row in cursor.fetchall():
+        yield row
+
+
+def row_to_payload(row: sqlite3.Row) -> Dict[str, Any]:
+    payload = {
+        "id": int(row["id"]),
+        "drive_label": row["drive_label"],
+        "path": row["path"],
+        "content": row["content"],
+        "dim": int(row["dim"]),
+        "embedding_norm": float(row["embedding_norm"] or 0.0),
+        "kind": row["kind"],
+        "updated_utc": row["updated_utc"],
+    }
+    try:
+        payload["embedding"] = json.loads(row["embedding"] or "[]")
+    except json.JSONDecodeError:
+        payload["embedding"] = []
+    try:
+        payload["metadata"] = json.loads(row["metadata"] or "{}")
+    except json.JSONDecodeError:
+        payload["metadata"] = {}
+    return payload

--- a/semantic/index.py
+++ b/semantic/index.py
@@ -1,0 +1,197 @@
+"""Semantic indexing helpers."""
+from __future__ import annotations
+
+import hashlib
+import logging
+import math
+import random
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional
+
+from core.paths import get_shards_dir
+
+from .config import SemanticConfig
+from .db import delete_all, semantic_connection, upsert_document
+
+LOGGER = logging.getLogger("videocatalog.semantic")
+
+
+@dataclass(slots=True)
+class IndexBuildStats:
+    """Summary for an indexing run."""
+
+    processed: int = 0
+    updated: int = 0
+    skipped: int = 0
+    shards_seen: int = 0
+
+    def as_dict(self) -> Dict[str, int]:
+        return {
+            "processed": self.processed,
+            "updated": self.updated,
+            "skipped": self.skipped,
+            "shards": self.shards_seen,
+        }
+
+
+def _hash_vector(key: str, *, dim: int) -> List[float]:
+    digest = hashlib.blake2b(key.encode("utf-8"), digest_size=32).digest()
+    seed = int.from_bytes(digest[:8], "big", signed=False)
+    rng = random.Random(seed)
+    values: List[float] = [rng.uniform(-1.0, 1.0) for _ in range(dim)]
+    norm = math.sqrt(sum(v * v for v in values)) or 1.0
+    return [v / norm for v in values]
+
+
+def _make_content(payload: Dict[str, Optional[str]]) -> str:
+    parts: List[str] = []
+    for value in payload.values():
+        if not value:
+            continue
+        parts.append(str(value))
+    return " \n".join(parts)
+
+
+def _shard_inventory_rows(shard_path: Path) -> Iterator[sqlite3.Row]:
+    if not shard_path.exists():
+        return iter(())
+    conn = sqlite3.connect(shard_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        cursor = conn.execute(
+            """
+            SELECT path, category, mime, ext, size_bytes, mtime_utc, drive_label
+            FROM inventory
+            WHERE path IS NOT NULL
+            """
+        )
+        for row in cursor.fetchall():
+            yield row
+    except sqlite3.DatabaseError:
+        LOGGER.warning("Shard missing inventory table: %s", shard_path)
+    finally:
+        conn.close()
+
+
+class SemanticIndexer:
+    """Build or rebuild the semantic index."""
+
+    def __init__(self, config: SemanticConfig) -> None:
+        self.config = config
+        self.working_dir = config.working_dir
+
+    def build(self, *, rebuild: bool = False) -> Dict[str, int]:
+        self.config.require_index_phase()
+        stats = IndexBuildStats()
+        shards_dir = get_shards_dir(self.working_dir)
+        shard_paths = sorted(path for path in shards_dir.glob("*.db"))
+        if rebuild:
+            LOGGER.info("Semantic index rebuild requested — clearing tables")
+        with semantic_connection(self.working_dir) as conn:
+            if rebuild:
+                delete_all(conn)
+            for shard in shard_paths:
+                stats.shards_seen += 1
+                stats.processed += self._index_shard(conn, shard)
+        return stats.as_dict()
+
+    def _index_shard(self, conn: sqlite3.Connection, shard_path: Path) -> int:
+        drive_label = shard_path.stem
+        processed = 0
+        for row in _shard_inventory_rows(shard_path):
+            processed += 1
+            path = row["path"]
+            category = row["category"] or ""
+            mime = row["mime"] or ""
+            ext = row["ext"] or ""
+            size = row["size_bytes"] or 0
+            mtime = row["mtime_utc"]
+            drive = row["drive_label"] or drive_label
+            content = _make_content(
+                {
+                    "path": path,
+                    "category": category,
+                    "mime": mime,
+                    "extension": ext,
+                }
+            )
+            embedding = _hash_vector(f"{drive}:{path}", dim=self.config.vector_dim)
+            metadata = {
+                "category": category,
+                "mime": mime,
+                "extension": ext,
+                "size_bytes": int(size or 0),
+                "mtime_utc": mtime,
+            }
+            upsert_document(
+                conn,
+                drive_label=drive,
+                path=path,
+                content=content,
+                embedding=embedding,
+                dim=self.config.vector_dim,
+                embedding_norm=1.0,
+                kind="inventory",
+                updated_utc=_normalize_timestamp(mtime),
+                metadata=metadata,
+            )
+        return processed
+
+
+class SemanticTranscriber:
+    """Populate transcript placeholders for multimedia rows."""
+
+    def __init__(self, config: SemanticConfig) -> None:
+        self.config = config
+
+    def run(self) -> Dict[str, int]:
+        self.config.require_transcribe_phase()
+        updates = 0
+        with semantic_connection(self.config.working_dir) as conn:
+            cursor = conn.execute(
+                "SELECT id, path, metadata FROM semantic_documents WHERE kind = 'inventory'"
+            )
+            rows = cursor.fetchall()
+            for row in rows:
+                metadata = _ensure_metadata_dict(row["metadata"])
+                if metadata.get("transcript"):
+                    continue
+                transcript = f"Transcript placeholder for {row['path']}"
+                conn.execute(
+                    "UPDATE semantic_documents SET metadata = json_set(COALESCE(metadata,'{}'), '$.transcript', ?) WHERE id = ?",
+                    (transcript, int(row["id"])),
+                )
+                updates += 1
+        return {"transcribed": updates}
+
+
+def _normalize_timestamp(value: Optional[str]) -> Optional[str]:
+    if value in (None, ""):
+        return None
+    try:
+        if value.endswith("Z"):
+            dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        else:
+            dt = datetime.fromisoformat(value)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    except Exception:
+        return str(value)
+
+
+def _ensure_metadata_dict(value: Optional[str]) -> Dict[str, object]:
+    if not value:
+        return {}
+    import json
+
+    try:
+        payload = json.loads(value)
+        if isinstance(payload, dict):
+            return payload
+        return {"value": payload}
+    except json.JSONDecodeError:
+        return {}

--- a/semantic/search.py
+++ b/semantic/search.py
@@ -1,0 +1,226 @@
+"""Semantic search helpers for embeddings and FTS queries."""
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+from .config import SemanticConfig
+from .db import semantic_connection
+
+
+@dataclass(slots=True)
+class SemanticDocument:
+    """In-memory representation of a semantic document."""
+
+    doc_id: int
+    drive_label: str
+    path: str
+    metadata: Dict[str, object]
+    embedding: List[float]
+
+
+@dataclass(slots=True)
+class SemanticSearchResult:
+    """Normalized search result row."""
+
+    path: str
+    drive_label: str
+    score: float
+    mode: str
+    snippet: Optional[str]
+    metadata: Dict[str, object]
+
+    def as_dict(self, rank: int) -> Dict[str, object]:
+        payload = {
+            "rank": rank,
+            "path": self.path,
+            "drive_label": self.drive_label,
+            "score": round(float(self.score), 6),
+            "mode": self.mode,
+            "metadata": self.metadata,
+        }
+        if self.snippet:
+            payload["snippet"] = self.snippet
+        return payload
+
+
+class SemanticSearcher:
+    """Execute ANN, FTS5, or hybrid semantic queries."""
+
+    def __init__(self, config: SemanticConfig) -> None:
+        self.config = config
+
+    def search(
+        self,
+        query: str,
+        *,
+        limit: int,
+        offset: int,
+        drive_label: Optional[str] = None,
+        mode: str = "ann",
+        hybrid: bool = False,
+    ) -> Tuple[List[Dict[str, object]], int]:
+        self.config.require_search_phase()
+        sanitized = query.strip()
+        if not sanitized:
+            return [], 0
+        mode = mode.lower()
+        if mode not in {"ann", "text", "hybrid"}:
+            mode = "ann"
+        use_hybrid = hybrid or mode == "hybrid"
+        base_mode = "ann" if mode == "hybrid" else mode
+        documents = self._load_documents(drive_label)
+        if not documents:
+            return [], 0
+        ann_scores: Dict[int, float] = {}
+        text_scores: Dict[int, Tuple[float, Optional[str]]] = {}
+        need_ann = base_mode == "ann" or use_hybrid
+        need_text = base_mode == "text" or use_hybrid
+        if need_ann:
+            ann_scores = self._ann_scores(sanitized, documents)
+        if need_text:
+            text_scores = self._text_scores(sanitized, drive_label)
+        scored = self._combine_scores(documents, ann_scores, text_scores, base_mode, use_hybrid)
+        paginated = scored[offset : offset + limit]
+        return [row.as_dict(rank=i + 1 + offset) for i, row in enumerate(paginated)], len(scored)
+
+    def _load_documents(self, drive_label: Optional[str]) -> List[SemanticDocument]:
+        documents: List[SemanticDocument] = []
+        with semantic_connection(self.config.working_dir) as conn:
+            sql = "SELECT id, drive_label, path, metadata, embedding FROM semantic_documents"
+            params: List[object] = []
+            if drive_label:
+                sql += " WHERE drive_label = ?"
+                params.append(drive_label)
+            cursor = conn.execute(sql, params)
+            for row in cursor.fetchall():
+                try:
+                    embedding = json.loads(row["embedding"] or "[]")
+                except json.JSONDecodeError:
+                    embedding = []
+                try:
+                    metadata = json.loads(row["metadata"] or "{}")
+                except json.JSONDecodeError:
+                    metadata = {}
+                documents.append(
+                    SemanticDocument(
+                        doc_id=int(row["id"]),
+                        drive_label=row["drive_label"],
+                        path=row["path"],
+                        metadata=metadata,
+                        embedding=list(map(float, embedding)),
+                    )
+                )
+        return documents
+
+    def _ann_scores(self, query: str, docs: Sequence[SemanticDocument]) -> Dict[int, float]:
+        query_vec = _normalize_vector([hash(token) % 997 for token in query.lower().split() or [query.lower()]])
+        scores: Dict[int, float] = {}
+        for doc in docs:
+            if not doc.embedding:
+                continue
+            sim = _cosine_similarity(query_vec, doc.embedding)
+            scores[doc.doc_id] = sim
+        return scores
+
+    def _text_scores(
+        self, query: str, drive_label: Optional[str]
+    ) -> Dict[int, Tuple[float, Optional[str]]]:
+        tokens = [token for token in query.strip().split() if token]
+        if not tokens:
+            return {}
+        fts_query = " AND ".join(f'"{token}"' for token in tokens)
+        results: Dict[int, Tuple[float, Optional[str]]] = {}
+        with semantic_connection(self.config.working_dir) as conn:
+            if drive_label:
+                cursor = conn.execute(
+                    """
+                    SELECT rowid, snippet(semantic_documents_fts, 0, '<b>', '</b>') AS snippet,
+                           bm25(semantic_documents_fts) AS rank
+                    FROM semantic_documents_fts
+                    WHERE semantic_documents_fts MATCH ? AND drive_label = ?
+                    ORDER BY rank ASC
+                    """,
+                    (fts_query, drive_label),
+                )
+            else:
+                cursor = conn.execute(
+                    """
+                    SELECT rowid, snippet(semantic_documents_fts, 0, '<b>', '</b>') AS snippet,
+                           bm25(semantic_documents_fts) AS rank
+                    FROM semantic_documents_fts
+                    WHERE semantic_documents_fts MATCH ?
+                    ORDER BY rank ASC
+                    """,
+                    (fts_query,),
+                )
+            for row in cursor.fetchall():
+                rank = float(row["rank"]) if row["rank"] is not None else 0.0
+                score = 1.0 / (1.0 + max(rank, 0.0))
+                results[int(row["rowid"])] = (score, row["snippet"])
+        return results
+
+    def _combine_scores(
+        self,
+        docs: Sequence[SemanticDocument],
+        ann_scores: Dict[int, float],
+        text_scores: Dict[int, Tuple[float, Optional[str]]],
+        mode: str,
+        use_hybrid: bool,
+    ) -> List[SemanticSearchResult]:
+        weight = float(self.config.hybrid_weight)
+        combined: List[SemanticSearchResult] = []
+        for doc in docs:
+            ann_score = ann_scores.get(doc.doc_id)
+            text_entry = text_scores.get(doc.doc_id)
+            text_score = text_entry[0] if text_entry else None
+            snippet = text_entry[1] if text_entry else None
+            final_score: Optional[float]
+            result_mode = mode
+            if use_hybrid and ann_score is not None and text_score is not None:
+                final_score = ann_score * weight + text_score * (1.0 - weight)
+                result_mode = "hybrid"
+            elif mode == "ann":
+                final_score = ann_score
+            elif mode == "text":
+                final_score = text_score
+            else:
+                final_score = ann_score
+            if final_score is None:
+                continue
+            combined.append(
+                SemanticSearchResult(
+                    path=doc.path,
+                    drive_label=doc.drive_label,
+                    score=float(final_score),
+                    mode=result_mode,
+                    snippet=snippet,
+                    metadata=doc.metadata,
+                )
+            )
+        combined.sort(key=lambda row: row.score, reverse=True)
+        return combined
+
+
+def _normalize_vector(values: Iterable[float]) -> List[float]:
+    vec = [float(v) for v in values]
+    if not vec:
+        return []
+    norm = math.sqrt(sum(v * v for v in vec))
+    if norm == 0:
+        return [0.0 for _ in vec]
+    return [v / norm for v in vec]
+
+
+def _cosine_similarity(a: Sequence[float], b: Sequence[float]) -> float:
+    if not a or not b:
+        return 0.0
+    length = min(len(a), len(b))
+    dot = sum(float(a[i]) * float(b[i]) for i in range(length))
+    norm_a = math.sqrt(sum(float(v) * float(v) for v in a))
+    norm_b = math.sqrt(sum(float(v) * float(v) for v in b))
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return dot / (norm_a * norm_b)


### PR DESCRIPTION
## Summary
- add a semantic helper package that builds embeddings, FTS rows, and performs ANN/hybrid queries
- wire new CLI options for semantic index, search, and transcription flows while respecting settings phases
- expose /v1/semantic/* routes and supporting data access plus models for API-driven search and maintenance
- update README documentation covering the CLI flags, API endpoints, and settings knobs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e7f2516f788327b21816bc5fcc3649