### PR TITLE
Add TV structure profiling scaffolding

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -64,6 +64,36 @@
     },
     "max_candidates": 5
   },
+  "tv": {
+    "enable": true,
+    "use_opensubtitles": true,
+    "opensubtitles_api_key": null,
+    "opensubtitles_read_kib": 64,
+    "opensubtitles_timeout": 15,
+    "tmdb": {
+      "api_key": null,
+      "lang": "en",
+      "year_tolerance": 1
+    },
+    "tmdb_timeout": 15,
+    "imdb_enabled": true,
+    "max_candidates": 5,
+    "threshold_low": 0.5,
+    "threshold_high": 0.8,
+    "weights": {
+      "series_canon": 0.3,
+      "series_nfo": 0.25,
+      "series_tmdb": 0.2,
+      "series_structure": 0.1,
+      "season_canon": 0.25,
+      "season_tmdb": 0.25,
+      "season_nfo": 0.15,
+      "ep_parse": 0.3,
+      "ep_tmdb": 0.25,
+      "ep_oshash": 0.2,
+      "ep_langs": 0.1
+    }
+  },
   "docpreview": {
     "enable": false,
     "max_pages": 6,

--- a/structure/__init__.py
+++ b/structure/__init__.py
@@ -7,6 +7,13 @@ from .service import (
     ensure_structure_tables,
     load_structure_settings,
 )
+from .tv_rules import analyze_season_folder, analyze_series_root
+from .tv_score import classify_confidence as tv_classify_confidence
+from .tv_score import score_episode as tv_score_episode
+from .tv_score import score_season as tv_score_season
+from .tv_score import score_series as tv_score_series
+from .tv_review import ensure_tv_tables
+from .tv_types import TVSettings, load_tv_settings
 
 __all__ = [
     "StructureProfiler",
@@ -14,4 +21,13 @@ __all__ = [
     "StructureSummary",
     "ensure_structure_tables",
     "load_structure_settings",
+    "analyze_series_root",
+    "analyze_season_folder",
+    "tv_score_series",
+    "tv_score_season",
+    "tv_score_episode",
+    "tv_classify_confidence",
+    "ensure_tv_tables",
+    "TVSettings",
+    "load_tv_settings",
 ]

--- a/structure/tv_guess.py
+++ b/structure/tv_guess.py
@@ -1,0 +1,105 @@
+"""GuessIt wrappers for TV series parsing."""
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from .guess import guessit  # type: ignore[attr-defined]
+from .guess import parse_nfo_identifiers
+from .tv_types import TVEpisodeGuess
+
+
+def _ensure_list(value: object) -> List[int]:
+    if isinstance(value, list):
+        result: List[int] = []
+        for item in value:
+            try:
+                result.append(int(item))
+            except (TypeError, ValueError):
+                continue
+        return result
+    if isinstance(value, int):
+        return [value]
+    try:
+        return [int(value)]  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return []
+
+
+def parse_episode(path: Path) -> TVEpisodeGuess:
+    """Parse *path* using GuessIt returning a normalized episode payload."""
+
+    if guessit is None:  # type: ignore[truthy-function]
+        return TVEpisodeGuess(raw={})
+    try:
+        payload = guessit(path.name, {"type": "episode"})
+    except Exception:
+        return TVEpisodeGuess(raw={})
+    episodes = _ensure_list(payload.get("episode"))
+    absolute = _ensure_list(payload.get("absolute_episode"))
+    season: Optional[int] = None
+    season_value = payload.get("season")
+    try:
+        season = int(season_value)
+    except (TypeError, ValueError):
+        season = None
+    air_date = None
+    if "date" in payload:
+        raw_date = payload.get("date")
+        if isinstance(raw_date, date):
+            air_date = raw_date
+    title = payload.get("episode_title")
+    if not isinstance(title, str):
+        title = payload.get("title") if isinstance(payload.get("title"), str) else None
+    series = payload.get("series") or payload.get("title")
+    if not isinstance(series, str):
+        series = None
+    guess = TVEpisodeGuess(
+        series=series,
+        season=season,
+        episodes=episodes,
+        absolute_numbers=absolute,
+        air_date=air_date,
+        title=title if isinstance(title, str) else None,
+        raw=dict(payload),
+    )
+    return guess
+
+
+def parse_series_nfo(nfo_path: Path) -> Dict[str, str]:
+    """Parse identifiers from a series-level .nfo file."""
+
+    return parse_nfo_identifiers(nfo_path)
+
+
+def parse_season_nfo(nfo_path: Path) -> Dict[str, str]:
+    return parse_nfo_identifiers(nfo_path)
+
+
+def parse_episode_nfo(nfo_path: Path) -> Dict[str, str]:
+    return parse_nfo_identifiers(nfo_path)
+
+
+def detect_subtitle_languages(subtitle_files: Iterable[Path]) -> List[str]:
+    """Guess subtitle languages from filename suffixes."""
+
+    langs: List[str] = []
+    for path in subtitle_files:
+        stem = path.stem
+        parts = stem.split(".")
+        if len(parts) < 2:
+            continue
+        language_token = parts[-1]
+        if len(language_token) in {2, 3} and language_token.isalpha():
+            langs.append(language_token.lower())
+    return sorted(set(langs))
+
+
+__all__ = [
+    "parse_episode",
+    "parse_series_nfo",
+    "parse_season_nfo",
+    "parse_episode_nfo",
+    "detect_subtitle_languages",
+]

--- a/structure/tv_review.py
+++ b/structure/tv_review.py
@@ -1,0 +1,281 @@
+"""TV review queue helpers and persistence."""
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from typing import Optional, Sequence
+
+from .tv_types import TVConfidenceBreakdown
+
+SERIES = "series"
+SEASON = "season"
+EPISODE = "episode"
+
+
+def ensure_tv_tables(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS tv_series_profile (
+            series_root TEXT PRIMARY KEY,
+            show_title TEXT,
+            show_year INTEGER,
+            ids_json TEXT,
+            seasons_found INTEGER,
+            assets_json TEXT,
+            issues_json TEXT,
+            confidence REAL,
+            updated_utc TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS tv_season_profile (
+            series_root TEXT,
+            season_path TEXT PRIMARY KEY,
+            season_number INTEGER,
+            episodes_found INTEGER,
+            expected_episodes INTEGER,
+            assets_json TEXT,
+            issues_json TEXT,
+            confidence REAL,
+            updated_utc TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS tv_episode_profile (
+            episode_path TEXT PRIMARY KEY,
+            series_root TEXT,
+            season_number INTEGER,
+            episode_numbers_json TEXT,
+            air_date TEXT,
+            parsed_title TEXT,
+            ids_json TEXT,
+            subtitles_json TEXT,
+            audio_langs_json TEXT,
+            issues_json TEXT,
+            confidence REAL,
+            updated_utc TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS tv_review_queue (
+            item_type TEXT,
+            item_key TEXT PRIMARY KEY,
+            confidence REAL,
+            reasons_json TEXT,
+            questions_json TEXT,
+            created_utc TEXT NOT NULL
+        )
+        """
+    )
+
+
+def _utc_now() -> str:
+    return datetime.utcnow().replace(tzinfo=timezone.utc).isoformat()
+
+
+def upsert_series_profile(
+    conn: sqlite3.Connection,
+    *,
+    series_root: str,
+    title: Optional[str],
+    year: Optional[int],
+    ids: Optional[dict],
+    seasons_found: int,
+    assets: dict,
+    issues: Sequence[str],
+    confidence: float,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO tv_series_profile (
+            series_root, show_title, show_year, ids_json, seasons_found, assets_json,
+            issues_json, confidence, updated_utc
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(series_root) DO UPDATE SET
+            show_title=excluded.show_title,
+            show_year=excluded.show_year,
+            ids_json=excluded.ids_json,
+            seasons_found=excluded.seasons_found,
+            assets_json=excluded.assets_json,
+            issues_json=excluded.issues_json,
+            confidence=excluded.confidence,
+            updated_utc=excluded.updated_utc
+        """,
+        (
+            series_root,
+            title,
+            year,
+            json.dumps(ids or {}),
+            seasons_found,
+            json.dumps(assets),
+            json.dumps(list(issues)),
+            confidence,
+            _utc_now(),
+        ),
+    )
+
+
+def upsert_season_profile(
+    conn: sqlite3.Connection,
+    *,
+    series_root: str,
+    season_path: str,
+    season_number: Optional[int],
+    episodes_found: int,
+    expected_episodes: Optional[int],
+    assets: dict,
+    issues: Sequence[str],
+    confidence: float,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO tv_season_profile (
+            series_root, season_path, season_number, episodes_found, expected_episodes,
+            assets_json, issues_json, confidence, updated_utc
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(season_path) DO UPDATE SET
+            series_root=excluded.series_root,
+            season_number=excluded.season_number,
+            episodes_found=excluded.episodes_found,
+            expected_episodes=excluded.expected_episodes,
+            assets_json=excluded.assets_json,
+            issues_json=excluded.issues_json,
+            confidence=excluded.confidence,
+            updated_utc=excluded.updated_utc
+        """,
+        (
+            series_root,
+            season_path,
+            season_number,
+            episodes_found,
+            expected_episodes,
+            json.dumps(assets),
+            json.dumps(list(issues)),
+            confidence,
+            _utc_now(),
+        ),
+    )
+
+
+def upsert_episode_profile(
+    conn: sqlite3.Connection,
+    *,
+    episode_path: str,
+    series_root: str,
+    season_number: Optional[int],
+    episodes_json: Sequence[int],
+    air_date: Optional[str],
+    parsed_title: Optional[str],
+    ids: Optional[dict],
+    subtitles: Sequence[str],
+    audio_languages: Sequence[str],
+    issues: Sequence[str],
+    confidence: float,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO tv_episode_profile (
+            episode_path, series_root, season_number, episode_numbers_json, air_date,
+            parsed_title, ids_json, subtitles_json, audio_langs_json, issues_json,
+            confidence, updated_utc
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(episode_path) DO UPDATE SET
+            series_root=excluded.series_root,
+            season_number=excluded.season_number,
+            episode_numbers_json=excluded.episode_numbers_json,
+            air_date=excluded.air_date,
+            parsed_title=excluded.parsed_title,
+            ids_json=excluded.ids_json,
+            subtitles_json=excluded.subtitles_json,
+            audio_langs_json=excluded.audio_langs_json,
+            issues_json=excluded.issues_json,
+            confidence=excluded.confidence,
+            updated_utc=excluded.updated_utc
+        """,
+        (
+            episode_path,
+            series_root,
+            season_number,
+            json.dumps(list(episodes_json)),
+            air_date,
+            parsed_title,
+            json.dumps(ids or {}),
+            json.dumps(list(subtitles)),
+            json.dumps(list(audio_languages)),
+            json.dumps(list(issues)),
+            confidence,
+            _utc_now(),
+        ),
+    )
+
+
+def enqueue_review_item(
+    conn: sqlite3.Connection,
+    *,
+    item_type: str,
+    item_key: str,
+    breakdown: TVConfidenceBreakdown,
+    questions: Optional[Sequence[str]] = None,
+) -> None:
+    reasons_json = json.dumps(breakdown.reasons)
+    questions_json = json.dumps(list(questions or []))
+    conn.execute(
+        """
+        INSERT INTO tv_review_queue (item_type, item_key, confidence, reasons_json, questions_json, created_utc)
+        VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT(item_key) DO UPDATE SET
+            item_type=excluded.item_type,
+            confidence=excluded.confidence,
+            reasons_json=excluded.reasons_json,
+            questions_json=excluded.questions_json,
+            created_utc=excluded.created_utc
+        """,
+        (
+            item_type,
+            item_key,
+            breakdown.confidence,
+            reasons_json,
+            questions_json,
+            _utc_now(),
+        ),
+    )
+
+
+def list_review_queue(
+    conn: sqlite3.Connection,
+    *,
+    item_type: Optional[str] = None,
+    limit: Optional[int] = None,
+    offset: int = 0,
+) -> Sequence[sqlite3.Row]:
+    conn.row_factory = sqlite3.Row
+    sql = "SELECT * FROM tv_review_queue"
+    params = []
+    if item_type:
+        sql += " WHERE item_type = ?"
+        params.append(item_type)
+    sql += " ORDER BY confidence ASC, created_utc ASC"
+    if limit is not None:
+        sql += " LIMIT ? OFFSET ?"
+        params.extend([limit, offset])
+    return conn.execute(sql, params).fetchall()
+
+
+__all__ = [
+    "SERIES",
+    "SEASON",
+    "EPISODE",
+    "ensure_tv_tables",
+    "upsert_series_profile",
+    "upsert_season_profile",
+    "upsert_episode_profile",
+    "enqueue_review_item",
+    "list_review_queue",
+]

--- a/structure/tv_rules.py
+++ b/structure/tv_rules.py
@@ -1,0 +1,187 @@
+"""Canonical folder detection rules for TV series."""
+from __future__ import annotations
+
+import os
+import re
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional, Tuple
+
+from .rules import SUBTITLE_EXTENSIONS, VIDEO_EXTENSIONS
+from .tv_types import TVEpisodeFile, TVSeasonInfo, TVSeriesInfo
+
+SERIES_CANONICAL_RE = re.compile(r"^(?P<title>.+?)\s*\((?P<year>\d{4})\)$")
+SEASON_NUMBER_RE = re.compile(r"^(?:season\s*)?(?P<number>\d{1,2})$", re.IGNORECASE)
+SEASON_CANONICAL_RE = re.compile(r"^(?:season\s*)?(?P<number>\d{1,2})$", re.IGNORECASE)
+SEASON_SPECIALS_RE = re.compile(r"^(?:season\s*)?(?:specials|0{1,2})$", re.IGNORECASE)
+SEASON_SHORT_RE = re.compile(r"^s(?P<number>\d{1,2})$", re.IGNORECASE)
+EPISODE_TOKEN_RE = re.compile(r"S(?P<season>\d{1,2})E(?P<episode>\d{2})(?:E(?P<episode2>\d{2}))?", re.IGNORECASE)
+DATE_TOKEN_RE = re.compile(r"(?P<year>20\d{2}|19\d{2})[-_.](?P<month>\d{2})[-_.](?P<day>\d{2})")
+ABSOLUTE_TOKEN_RE = re.compile(r"(?:^|[^\d])(?P<number>\d{2,4})(?:[^\d]|$)")
+
+LOCAL_SHOW_NFO = {"tvshow.nfo", "show.nfo"}
+LOCAL_SEASON_NFO = {"season.nfo"}
+LOCAL_EPISODE_NFO = {"episode.nfo"}
+LOCAL_POSTERS = {"poster.jpg", "poster.png", "folder.jpg", "folder.png"}
+LOCAL_FANART = {"fanart.jpg", "fanart.png", "background.jpg"}
+EXTRAS_FOLDERS = {"extras", "featurettes", "bonus"}
+
+
+def _iter_visible_entries(folder: Path) -> Iterator[os.DirEntry[str]]:
+    with os.scandir(folder) as handle:
+        for entry in handle:
+            if entry.name.startswith("."):
+                continue
+            yield entry
+
+
+def _collect_assets(entries: Iterable[Path]) -> Dict[str, object]:
+    assets: Dict[str, object] = {
+        "poster": False,
+        "fanart": False,
+        "subtitles": [],
+        "nfo": None,
+    }
+    subtitles: List[str] = []
+    extras: Dict[str, List[str]] = defaultdict(list)
+    for entry in entries:
+        lower = entry.name.lower()
+        if lower in LOCAL_POSTERS:
+            assets["poster"] = True
+            continue
+        if lower in LOCAL_FANART:
+            assets["fanart"] = True
+            continue
+        if lower in LOCAL_SHOW_NFO or lower in LOCAL_SEASON_NFO or lower in LOCAL_EPISODE_NFO:
+            assets["nfo"] = entry.name
+            continue
+        if entry.suffix.lower() in SUBTITLE_EXTENSIONS:
+            subtitles.append(entry.name)
+            continue
+        try:
+            is_dir = entry.is_dir()
+        except OSError:
+            is_dir = False
+        if is_dir and entry.name.lower() in EXTRAS_FOLDERS:
+            extras[entry.name].append(entry.name)
+    if subtitles:
+        assets["subtitles"] = sorted(set(subtitles))
+    if extras:
+        assets["extras"] = {key: sorted(values) for key, values in extras.items()}
+    return assets
+
+
+def _detect_series_name(path: Path) -> Tuple[Optional[str], Optional[int], bool]:
+    match = SERIES_CANONICAL_RE.match(path.name)
+    if match:
+        title = match.group("title").strip()
+        year = int(match.group("year"))
+        return title, year, True
+    return path.name, None, False
+
+
+def _detect_season_number(name: str) -> Tuple[Optional[int], bool, bool]:
+    lowered = name.lower()
+    clean = lowered.replace("_", " ").replace("-", " ")
+    tokens = clean.split()
+    canonical = False
+    specials = False
+    if len(tokens) == 2 and tokens[0] == "season":
+        token = tokens[1]
+        if token.isdigit():
+            canonical = True
+            return int(token), canonical, specials
+        if token in {"0", "00"}:
+            canonical = True
+            specials = True
+            return 0, canonical, specials
+        if token == "specials":
+            canonical = True
+            specials = True
+            return 0, canonical, specials
+    if SEASON_SPECIALS_RE.match(clean):
+        specials = True
+        canonical = True
+        return 0, canonical, specials
+    match = SEASON_CANONICAL_RE.match(clean)
+    if match and match.group("number"):
+        canonical = True
+        return int(match.group("number")), canonical, specials
+    match = SEASON_SHORT_RE.match(clean)
+    if match and match.group("number"):
+        return int(match.group("number")), canonical, specials
+    return None, canonical, specials
+
+
+def _detect_episode_assets(folder: Path) -> Dict[str, object]:
+    assets: Dict[str, object] = {"subtitles": []}
+    subtitles: List[str] = []
+    for entry in folder.iterdir():
+        if entry.suffix.lower() in SUBTITLE_EXTENSIONS:
+            subtitles.append(entry.name)
+    if subtitles:
+        assets["subtitles"] = sorted(subtitles)
+    else:
+        assets.pop("subtitles", None)
+    return assets
+
+
+def _collect_episode_files(folder: Path) -> List[TVEpisodeFile]:
+    episodes: List[TVEpisodeFile] = []
+    subtitle_map: Dict[str, List[Path]] = defaultdict(list)
+    for entry in folder.iterdir():
+        if not entry.is_file():
+            continue
+        suffix = entry.suffix.lower()
+        if suffix in SUBTITLE_EXTENSIONS:
+            subtitle_map[entry.stem].append(entry)
+            continue
+        if suffix not in VIDEO_EXTENSIONS:
+            continue
+        try:
+            size_bytes = entry.stat().st_size
+        except OSError:
+            size_bytes = 0
+        subtitles = subtitle_map.get(entry.stem, [])
+        episodes.append(TVEpisodeFile(path=entry, size_bytes=size_bytes, subtitles=list(subtitles)))
+    return sorted(episodes, key=lambda item: item.path.name)
+
+
+def analyze_season_folder(path: Path) -> TVSeasonInfo:
+    season_number, canonical, specials = _detect_season_number(path.name)
+    issues: List[str] = []
+    if specials and season_number != 0:
+        issues.append("specials_misnumbered")
+    entries = [Path(entry.path) for entry in _iter_visible_entries(path)]
+    assets = _collect_assets(entries)
+    episodes = _collect_episode_files(path)
+    if not episodes:
+        issues.append("no_episodes")
+    return TVSeasonInfo(path=path, season_number=season_number, canonical=canonical, assets=assets, issues=issues, episodes=episodes)
+
+
+def analyze_series_root(path: Path) -> TVSeriesInfo:
+    title, year, canonical = _detect_series_name(path)
+    entries = [Path(entry.path) for entry in _iter_visible_entries(path)]
+    assets = _collect_assets(entries)
+    seasons: List[TVSeasonInfo] = []
+    issues: List[str] = []
+    for entry in _iter_visible_entries(path):
+        if entry.is_dir():
+            season_info = analyze_season_folder(Path(entry.path))
+            seasons.append(season_info)
+    if not seasons:
+        issues.append("no_seasons")
+    return TVSeriesInfo(root=path, title=title, year=year, canonical=canonical, assets=assets, issues=issues, seasons=sorted(seasons, key=lambda s: (s.season_number if s.season_number is not None else 9999, s.path.name)))
+
+
+__all__ = [
+    "SERIES_CANONICAL_RE",
+    "SEASON_CANONICAL_RE",
+    "SEASON_SPECIALS_RE",
+    "EPISODE_TOKEN_RE",
+    "DATE_TOKEN_RE",
+    "ABSOLUTE_TOKEN_RE",
+    "analyze_series_root",
+    "analyze_season_folder",
+]

--- a/structure/tv_score.py
+++ b/structure/tv_score.py
@@ -1,0 +1,130 @@
+"""Confidence scoring for TV series hierarchy."""
+from __future__ import annotations
+
+from typing import Dict, Iterable, Sequence
+
+from .tv_types import (
+    TVConfidenceBreakdown,
+    TVEpisodeVerification,
+    TVScoringSettings,
+    TVSeasonVerification,
+    TVSeriesInfo,
+    TVSeriesVerification,
+)
+
+
+def _clamp(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+def _apply_penalties(base: float, issues: Sequence[str]) -> float:
+    if not issues:
+        return base
+    penalty = 0.05 * len(issues)
+    return max(0.0, base - penalty)
+
+
+def score_series(
+    series: TVSeriesInfo,
+    verification: TVSeriesVerification,
+    *,
+    has_nfo: bool,
+    season_alignment: bool,
+    issues: Sequence[str],
+    settings: TVScoringSettings,
+) -> TVConfidenceBreakdown:
+    confidence = 0.0
+    signals: Dict[str, float] = {}
+    reasons = []
+    if series.canonical:
+        confidence += settings.series_canon
+        signals["canonical"] = settings.series_canon
+        reasons.append("series_canonical")
+    if has_nfo:
+        confidence += settings.series_nfo
+        signals["nfo"] = settings.series_nfo
+        reasons.append("series_nfo")
+    if verification.tmdb_id and verification.name_score >= 0.6:
+        confidence += settings.series_tmdb * min(1.0, verification.name_score + 0.2)
+        signals["tmdb"] = settings.series_tmdb * min(1.0, verification.name_score + 0.2)
+        reasons.append("series_tmdb_match")
+    if season_alignment:
+        confidence += settings.series_structure
+        signals["structure"] = settings.series_structure
+        reasons.append("season_alignment")
+    confidence = _apply_penalties(confidence, issues)
+    return TVConfidenceBreakdown(confidence=_clamp(confidence), reasons=reasons, signals=signals)
+
+
+def score_season(
+    season_verification: TVSeasonVerification,
+    *,
+    canonical: bool,
+    has_nfo: bool,
+    issues: Sequence[str],
+    settings: TVScoringSettings,
+) -> TVConfidenceBreakdown:
+    confidence = 0.0
+    signals: Dict[str, float] = {}
+    reasons = []
+    if canonical:
+        confidence += settings.season_canon
+        signals["canonical"] = settings.season_canon
+        reasons.append("season_canonical")
+    if season_verification.tmdb_season_id and season_verification.expected_episodes is not None:
+        confidence += settings.season_tmdb
+        signals["tmdb"] = settings.season_tmdb
+        reasons.append("season_tmdb_match")
+    if has_nfo:
+        confidence += settings.season_nfo
+        signals["nfo"] = settings.season_nfo
+        reasons.append("season_nfo")
+    confidence = _apply_penalties(confidence, issues)
+    return TVConfidenceBreakdown(confidence=_clamp(confidence), reasons=reasons, signals=signals)
+
+
+def score_episode(
+    verification: TVEpisodeVerification,
+    *,
+    parsed_ok: bool,
+    subtitles_present: bool,
+    issues: Sequence[str],
+    settings: TVScoringSettings,
+) -> TVConfidenceBreakdown:
+    confidence = 0.0
+    signals: Dict[str, float] = {}
+    reasons = []
+    if parsed_ok:
+        confidence += settings.episode_parse
+        signals["parse"] = settings.episode_parse
+        reasons.append("episode_parsed")
+    if verification.tmdb_episode_id or verification.tmdb_air_date:
+        confidence += settings.episode_tmdb
+        signals["tmdb"] = settings.episode_tmdb
+        reasons.append("episode_tmdb")
+    if verification.oshash_match:
+        confidence += settings.episode_oshash
+        signals["oshash"] = settings.episode_oshash
+        reasons.append("episode_oshash")
+    if subtitles_present:
+        confidence += settings.episode_langs
+        signals["subtitles"] = settings.episode_langs
+        reasons.append("subtitles_present")
+    confidence = _apply_penalties(confidence, issues)
+    return TVConfidenceBreakdown(confidence=_clamp(confidence), reasons=reasons, signals=signals)
+
+
+def classify_confidence(confidence: float, settings: TVScoringSettings) -> str:
+    if confidence >= settings.threshold_high:
+        return "high"
+    if confidence >= settings.threshold_low:
+        return "medium"
+    return "low"
+
+
+__all__ = [
+    "score_series",
+    "score_season",
+    "score_episode",
+    "classify_confidence",
+]

--- a/structure/tv_types.py
+++ b/structure/tv_types.py
@@ -1,0 +1,241 @@
+"""Dataclasses shared by TV structure profiling modules."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence
+
+
+@dataclass(slots=True)
+class TVEpisodeFile:
+    """Representation of a TV episode file detected on disk."""
+
+    path: Path
+    size_bytes: int
+    subtitles: List[Path] = field(default_factory=list)
+    audio_languages: List[str] = field(default_factory=list)
+    parsed_title: Optional[str] = None
+
+
+@dataclass(slots=True)
+class TVEpisodeGuess:
+    """Normalized GuessIt payload for an episode."""
+
+    series: Optional[str] = None
+    season: Optional[int] = None
+    episodes: List[int] = field(default_factory=list)
+    absolute_numbers: List[int] = field(default_factory=list)
+    air_date: Optional[date] = None
+    title: Optional[str] = None
+    raw: Dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class TVSeasonInfo:
+    """Filesystem-level information about a season folder."""
+
+    path: Path
+    season_number: Optional[int]
+    canonical: bool
+    assets: Dict[str, object] = field(default_factory=dict)
+    issues: List[str] = field(default_factory=list)
+    episodes: List[TVEpisodeFile] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class TVSeriesInfo:
+    """Filesystem-level information about a series root."""
+
+    root: Path
+    title: Optional[str]
+    year: Optional[int]
+    canonical: bool
+    assets: Dict[str, object] = field(default_factory=dict)
+    issues: List[str] = field(default_factory=list)
+    seasons: List[TVSeasonInfo] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class TVVerificationCandidate:
+    """Candidate identification pulled from an external service."""
+
+    source: str
+    candidate_id: Optional[str]
+    title: Optional[str]
+    year: Optional[int]
+    score: float
+    extra: Dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class TVEpisodeVerification:
+    """Verification metadata for a specific episode."""
+
+    candidates: List[TVVerificationCandidate] = field(default_factory=list)
+    tmdb_episode_id: Optional[str] = None
+    imdb_episode_id: Optional[str] = None
+    tmdb_air_date: Optional[str] = None
+    oshash_match: Optional[Dict[str, object]] = None
+
+
+@dataclass(slots=True)
+class TVSeasonVerification:
+    """Verification metadata for a season."""
+
+    tmdb_season_id: Optional[str] = None
+    expected_episodes: Optional[int] = None
+    candidates: List[TVVerificationCandidate] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class TVSeriesVerification:
+    """Verification metadata for a series root."""
+
+    candidates: List[TVVerificationCandidate] = field(default_factory=list)
+    tmdb_id: Optional[str] = None
+    imdb_id: Optional[str] = None
+    name_score: float = 0.0
+
+    def top_candidates(self, limit: int) -> Sequence[TVVerificationCandidate]:
+        return self.candidates[:limit]
+
+
+@dataclass(slots=True)
+class TVConfidenceBreakdown:
+    """Confidence score and supporting reasons for an entity."""
+
+    confidence: float
+    reasons: List[str] = field(default_factory=list)
+    signals: Dict[str, float] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class TVScoringSettings:
+    """Weights and thresholds used for TV scoring."""
+
+    series_canon: float = 0.30
+    series_nfo: float = 0.25
+    series_tmdb: float = 0.20
+    series_structure: float = 0.10
+    season_canon: float = 0.25
+    season_tmdb: float = 0.25
+    season_nfo: float = 0.15
+    episode_parse: float = 0.30
+    episode_tmdb: float = 0.25
+    episode_oshash: float = 0.20
+    episode_langs: float = 0.10
+    threshold_low: float = 0.50
+    threshold_high: float = 0.80
+
+
+@dataclass(slots=True)
+class TVSettings:
+    """High level configuration for TV profiling."""
+
+    enable: bool = True
+    use_opensubtitles: bool = True
+    opensubtitles_api_key: Optional[str] = None
+    opensubtitles_read_kib: int = 64
+    opensubtitles_timeout: float = 15.0
+    tmdb_api_key: Optional[str] = None
+    tmdb_lang: str = "en"
+    tmdb_year_tolerance: int = 1
+    tmdb_timeout: float = 15.0
+    imdb_enabled: bool = True
+    max_candidates: int = 5
+    scoring: TVScoringSettings = field(default_factory=TVScoringSettings)
+
+
+def load_tv_settings(data: Dict[str, object]) -> TVSettings:
+    section = data.get("tv") if isinstance(data, dict) else None
+    if not isinstance(section, dict):
+        section = {}
+    scoring_section = section.get("weights") if isinstance(section.get("weights"), dict) else {}
+    settings = TVSettings()
+    settings.enable = bool(section.get("enable", settings.enable))
+    settings.use_opensubtitles = bool(section.get("use_opensubtitles", settings.use_opensubtitles))
+    settings.opensubtitles_api_key = (
+        str(section.get("opensubtitles_api_key")).strip() or None
+        if "opensubtitles_api_key" in section
+        else settings.opensubtitles_api_key
+    )
+    try:
+        settings.opensubtitles_read_kib = int(section.get("opensubtitles_read_kib", settings.opensubtitles_read_kib))
+    except (TypeError, ValueError):
+        pass
+    try:
+        settings.opensubtitles_timeout = float(section.get("opensubtitles_timeout", settings.opensubtitles_timeout))
+    except (TypeError, ValueError):
+        pass
+    tmdb_section_raw = section.get("tmdb")
+    if isinstance(tmdb_section_raw, str):
+        settings.tmdb_api_key = tmdb_section_raw.strip() or settings.tmdb_api_key
+        tmdb_section = {}
+    elif isinstance(tmdb_section_raw, dict):
+        tmdb_section = tmdb_section_raw
+    else:
+        tmdb_section = {}
+    if tmdb_section:
+        settings.tmdb_api_key = (
+            str(tmdb_section.get("api_key")).strip() or None
+            if "api_key" in tmdb_section
+            else settings.tmdb_api_key
+        )
+        settings.tmdb_lang = str(tmdb_section.get("lang", settings.tmdb_lang))
+        try:
+            settings.tmdb_year_tolerance = int(tmdb_section.get("year_tolerance", settings.tmdb_year_tolerance))
+        except (TypeError, ValueError):
+            pass
+    try:
+        settings.tmdb_timeout = float(section.get("tmdb_timeout", settings.tmdb_timeout))
+    except (TypeError, ValueError):
+        pass
+    settings.imdb_enabled = bool(section.get("imdb_enabled", settings.imdb_enabled))
+    try:
+        settings.max_candidates = max(1, int(section.get("max_candidates", settings.max_candidates)))
+    except (TypeError, ValueError):
+        pass
+    scoring = settings.scoring
+    for key, default in (
+        ("series_canon", scoring.series_canon),
+        ("series_nfo", scoring.series_nfo),
+        ("series_tmdb", scoring.series_tmdb),
+        ("series_structure", scoring.series_structure),
+        ("season_canon", scoring.season_canon),
+        ("season_tmdb", scoring.season_tmdb),
+        ("season_nfo", scoring.season_nfo),
+        ("ep_parse", scoring.episode_parse),
+        ("ep_tmdb", scoring.episode_tmdb),
+        ("ep_oshash", scoring.episode_oshash),
+        ("ep_langs", scoring.episode_langs),
+    ):
+        try:
+            setattr(scoring, key if not key.startswith("ep_") else key.replace("ep_", "episode_"), float(scoring_section.get(key, default)))
+        except (TypeError, ValueError):
+            continue
+    try:
+        scoring.threshold_low = float(section.get("threshold_low", scoring.threshold_low))
+    except (TypeError, ValueError):
+        pass
+    try:
+        scoring.threshold_high = float(section.get("threshold_high", scoring.threshold_high))
+    except (TypeError, ValueError):
+        pass
+    return settings
+
+
+__all__ = [
+    "TVEpisodeFile",
+    "TVEpisodeGuess",
+    "TVSeasonInfo",
+    "TVSeriesInfo",
+    "TVVerificationCandidate",
+    "TVEpisodeVerification",
+    "TVSeasonVerification",
+    "TVSeriesVerification",
+    "TVConfidenceBreakdown",
+    "TVScoringSettings",
+    "TVSettings",
+    "load_tv_settings",
+]

--- a/structure/tv_verify.py
+++ b/structure/tv_verify.py
@@ -1,0 +1,311 @@
+"""External verification helpers for TV series."""
+from __future__ import annotations
+
+import logging
+import os
+from functools import lru_cache
+from typing import Dict, Iterable, List, Optional, Sequence
+
+import requests
+
+try:  # pragma: no cover - optional dependency
+    from rapidfuzz import fuzz  # type: ignore
+except Exception:  # pragma: no cover - gracefully degrade
+    fuzz = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    import tmdbsimple as tmdb  # type: ignore
+except Exception:  # pragma: no cover - gracefully degrade
+    tmdb = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    from imdb import Cinemagoer  # type: ignore
+except Exception:  # pragma: no cover - gracefully degrade
+    Cinemagoer = None  # type: ignore
+
+from .tv_types import (
+    TVEpisodeFile,
+    TVEpisodeVerification,
+    TVSeasonVerification,
+    TVSeriesInfo,
+    TVSeriesVerification,
+    TVSettings,
+    TVVerificationCandidate,
+)
+from .verify import compute_oshash_signature
+
+LOGGER = logging.getLogger("videocatalog.tv.verify")
+
+OPEN_SUBTITLES_URL = "https://api.opensubtitles.com/api/v1/subtitles"
+
+
+def _score_against_names(name: Optional[str], names: Sequence[str]) -> float:
+    if not name:
+        return 0.0
+    if not names:
+        return 0.0
+    if fuzz is None:
+        return 0.0
+    best = 0.0
+    for candidate in names:
+        try:
+            score = float(fuzz.token_sort_ratio(name, candidate)) / 100.0
+        except Exception:
+            continue
+        best = max(best, score)
+    return best
+
+
+@lru_cache(maxsize=1)
+def _cinemagoer_client() -> Optional[Cinemagoer]:  # type: ignore[valid-type]
+    if Cinemagoer is None:
+        return None
+    try:
+        return Cinemagoer()
+    except Exception:
+        return None
+
+
+def _tmdb_request(path: str, params: Dict[str, object], settings: TVSettings) -> Optional[Dict[str, object]]:
+    api_key = settings.tmdb_api_key or os.environ.get("TMDB_API_KEY")
+    if not api_key:
+        LOGGER.debug("TMDb request skipped: missing api key")
+        return None
+    if tmdb is not None:
+        tmdb.API_KEY = api_key  # type: ignore[attr-defined]
+    url = f"https://api.themoviedb.org/3{path}"
+    params = dict(params)
+    params.setdefault("api_key", api_key)
+    params.setdefault("language", settings.tmdb_lang)
+    try:
+        response = requests.get(url, params=params, timeout=settings.tmdb_timeout)
+    except requests.RequestException as exc:
+        LOGGER.debug("TMDb request failed: %s", exc)
+        return None
+    if response.status_code >= 300:
+        LOGGER.debug("TMDb HTTP %s for %s", response.status_code, path)
+        return None
+    try:
+        return response.json()
+    except ValueError:
+        LOGGER.debug("TMDb returned invalid JSON for %s", path)
+        return None
+
+
+def _tmdb_search_series(title: str, year: Optional[int], settings: TVSettings) -> List[Dict[str, object]]:
+    params: Dict[str, object] = {"query": title}
+    if year:
+        params["first_air_date_year"] = year
+    payload = _tmdb_request("/search/tv", params, settings)
+    results = payload.get("results") if isinstance(payload, dict) else None
+    if isinstance(results, list):
+        return [result for result in results if isinstance(result, dict)]
+    return []
+
+
+def verify_series(series: TVSeriesInfo, *, settings: TVSettings, names: Iterable[str]) -> TVSeriesVerification:
+    names_list = [series.root.name]
+    names_list.extend(str(name) for name in names if name)
+    if series.title:
+        names_list.append(series.title)
+    candidates: List[TVVerificationCandidate] = []
+    if series.title:
+        for entry in _tmdb_search_series(series.title, series.year, settings):
+            title = entry.get("name") or entry.get("original_name")
+            year = entry.get("first_air_date")
+            first_year = None
+            if isinstance(year, str) and len(year) >= 4 and year[:4].isdigit():
+                first_year = int(year[:4])
+            score = _score_against_names(str(title) if title else "", names_list)
+            candidate = TVVerificationCandidate(
+                source="tmdb",
+                candidate_id=str(entry.get("id")) if entry.get("id") is not None else None,
+                title=str(title) if title else None,
+                year=first_year,
+                score=score,
+                extra={"vote_average": entry.get("vote_average"), "popularity": entry.get("popularity")},
+            )
+            candidates.append(candidate)
+    if settings.imdb_enabled and series.title:
+        client = _cinemagoer_client()
+        if client is not None:
+            try:
+                results = client.search_movie(series.title)
+            except Exception:
+                results = []
+            for item in results[: settings.max_candidates]:
+                getter = item.get if hasattr(item, "get") else (lambda key, default=None: default)
+                kind = getter("kind")
+                if kind not in {"tv series", "tv mini series", "tv special"}:
+                    continue
+                imdb_id = None
+                movie_id = getattr(item, "movieID", None)
+                if movie_id:
+                    imdb_id = f"tt{movie_id}"
+                elif getter("movieID"):
+                    imdb_id = f"tt{getter('movieID')}"
+                year = getter("year")
+                title = getter("title")
+                score = _score_against_names(str(title) if title else "", names_list)
+                candidates.append(
+                    TVVerificationCandidate(
+                        source="imdb",
+                        candidate_id=imdb_id,
+                        title=str(title) if title else None,
+                        year=int(year) if isinstance(year, int) else None,
+                        score=score,
+                        extra={},
+                    )
+                )
+    candidates.sort(key=lambda item: item.score, reverse=True)
+    best = candidates[0] if candidates else None
+    verification = TVSeriesVerification(candidates=candidates, name_score=best.score if best else 0.0)
+    if best and best.source == "tmdb":
+        verification.tmdb_id = best.candidate_id
+    if best and best.source == "imdb":
+        verification.imdb_id = best.candidate_id
+    return verification
+
+
+def verify_season(
+    tmdb_id: Optional[str],
+    season_number: Optional[int],
+    *,
+    settings: TVSettings,
+) -> TVSeasonVerification:
+    verification = TVSeasonVerification()
+    if not tmdb_id or season_number is None:
+        return verification
+    payload = _tmdb_request(f"/tv/{tmdb_id}/season/{season_number}", {}, settings)
+    if not isinstance(payload, dict):
+        return verification
+    episodes = payload.get("episodes")
+    if isinstance(episodes, list):
+        verification.expected_episodes = sum(1 for entry in episodes if isinstance(entry, dict))
+    verification.tmdb_season_id = str(payload.get("id")) if payload.get("id") is not None else None
+    return verification
+
+
+def verify_episode(
+    tmdb_id: Optional[str],
+    season_number: Optional[int],
+    episode_numbers: Sequence[int],
+    episode_file: TVEpisodeFile,
+    *,
+    settings: TVSettings,
+    names: Iterable[str],
+) -> TVEpisodeVerification:
+    verification = TVEpisodeVerification()
+    if tmdb_id and season_number is not None and episode_numbers:
+        payload = _tmdb_request(
+            f"/tv/{tmdb_id}/season/{season_number}/episode/{episode_numbers[0]}",
+            {},
+            settings,
+        )
+        if isinstance(payload, dict):
+            title = payload.get("name")
+            score = _score_against_names(str(title) if title else "", list(names))
+            verification.candidates.append(
+                TVVerificationCandidate(
+                    source="tmdb",
+                    candidate_id=str(payload.get("id")) if payload.get("id") is not None else None,
+                    title=str(title) if title else None,
+                    year=None,
+                    score=score,
+                    extra={"air_date": payload.get("air_date")},
+                )
+            )
+            verification.tmdb_episode_id = str(payload.get("id")) if payload.get("id") is not None else None
+            verification.tmdb_air_date = payload.get("air_date") if isinstance(payload.get("air_date"), str) else None
+    if settings.use_opensubtitles:
+        oshash = compute_oshash_signature(
+            episode_file.path,
+            block_kib=settings.opensubtitles_read_kib,
+        )
+        if oshash:
+            response = _opensubtitles_lookup(oshash, settings, names)
+            if response:
+                verification.oshash_match = response
+                imdb_id = response.get("imdb_id")
+                verification.candidates.append(
+                    TVVerificationCandidate(
+                        source="opensubs",
+                        candidate_id=str(imdb_id) if imdb_id else None,
+                        title=response.get("title"),
+                        year=response.get("year") if isinstance(response.get("year"), int) else None,
+                        score=float(response.get("score", 0.0)),
+                        extra={"hash": oshash[0]},
+                    )
+                )
+                if imdb_id:
+                    verification.imdb_episode_id = str(imdb_id)
+    verification.candidates.sort(key=lambda item: item.score, reverse=True)
+    return verification
+
+
+def _opensubtitles_lookup(signature: Optional[Sequence[object]], settings: TVSettings, names: Iterable[str]) -> Optional[Dict[str, object]]:
+    if not signature:
+        return None
+    api_key = settings.opensubtitles_api_key or os.environ.get("OPENSUBTITLES_API_KEY")
+    if not api_key:
+        LOGGER.debug("OpenSubtitles lookup skipped: missing api key")
+        return None
+    token = signature[0]
+    size = signature[1]
+    params = {
+        "moviehash": token,
+        "moviebytesize": size,
+    }
+    headers = {
+        "Api-Key": api_key,
+        "Content-Type": "application/json",
+        "User-Agent": "VideoCatalog/1.0 (tv verify)",
+    }
+    try:
+        response = requests.get(OPEN_SUBTITLES_URL, params=params, headers=headers, timeout=settings.opensubtitles_timeout)
+    except requests.RequestException as exc:
+        LOGGER.debug("OpenSubtitles request failed: %s", exc)
+        return None
+    if response.status_code >= 300:
+        LOGGER.debug("OpenSubtitles HTTP %s", response.status_code)
+        return None
+    try:
+        payload = response.json()
+    except ValueError:
+        LOGGER.debug("OpenSubtitles returned invalid JSON")
+        return None
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(data, list):
+        return None
+    names_list = list(names)
+    best_entry: Optional[Dict[str, object]] = None
+    best_score = 0.0
+    for entry in data:
+        attributes = entry.get("attributes") if isinstance(entry, dict) else None
+        if not isinstance(attributes, dict):
+            continue
+        feature = attributes.get("feature_details") if isinstance(attributes.get("feature_details"), dict) else None
+        if not isinstance(feature, dict):
+            feature = attributes.get("movie") if isinstance(attributes.get("movie"), dict) else None
+        if not isinstance(feature, dict):
+            continue
+        title = feature.get("title") or feature.get("name")
+        score = _score_against_names(str(title) if title else "", names_list)
+        if score > best_score:
+            best_score = score
+            best_entry = {
+                "imdb_id": feature.get("imdb_id") or feature.get("imdbid"),
+                "title": title,
+                "year": feature.get("year") or feature.get("release_year"),
+                "score": score,
+                "moviehash": token,
+                "size": size,
+            }
+    return best_entry
+
+
+__all__ = [
+    "verify_series",
+    "verify_season",
+    "verify_episode",
+]


### PR DESCRIPTION
## Summary
- add filesystem analysis helpers for TV series, seasons, and episodes plus GuessIt parsing utilities
- integrate TV verification, scoring, and review persistence workflows with new shared dataclasses
- expose TV configuration defaults and exports for downstream services

## Testing
- python -m compileall structure

------
https://chatgpt.com/codex/tasks/task_e_68e844f794bc832790aac69dd3e48ad5