### PR TITLE
Add music name parsing utilities with scoring and review tests

### DIFF
--- a/musicnames/__init__.py
+++ b/musicnames/__init__.py
@@ -1,0 +1,11 @@
+"""Utilities for parsing music file names and folders."""
+
+from .parse import parse_music_name
+from .score import score_parse_result
+from .review import generate_review_bundle
+
+__all__ = [
+    "parse_music_name",
+    "score_parse_result",
+    "generate_review_bundle",
+]

--- a/musicnames/normalize.py
+++ b/musicnames/normalize.py
@@ -1,0 +1,102 @@
+"""Reusable normalisation helpers for music name parsing."""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+from . import patterns
+
+_AUDIO_EXTENSIONS = {
+    "mp3",
+    "flac",
+    "aac",
+    "m4a",
+    "wav",
+    "ogg",
+    "wma",
+    "alac",
+    "aiff",
+    "opus",
+}
+
+_SANITISED_SUFFIXES = (".part",)
+
+_QUALITY_PATTERN = re.compile(
+    r"\s*[\(\[\{](?:\d{3,4}p|\d{2,4}kbps|dvd|bluray)[^\)\]\}]*[\)\]\}]",
+    re.IGNORECASE,
+)
+
+
+def strip_extension(name: str) -> str:
+    """Remove a known audio extension from *name*."""
+
+    if not name:
+        return ""
+
+    lowered = name.lower()
+    for suffix in _SANITISED_SUFFIXES:
+        if lowered.endswith(suffix):
+            lowered = lowered[: -len(suffix)]
+            name = name[: -len(suffix)]
+            break
+
+    base, dot, ext = name.rpartition(".")
+    if dot and ext.lower() in _AUDIO_EXTENSIONS:
+        return base
+    return name
+
+
+def swap_separators_for_spaces(text: str) -> str:
+    """Replace underscores and dot runs with single spaces."""
+
+    if not text:
+        return ""
+    swapped = re.sub(r"_+", " ", text)
+    swapped = re.sub(r"(?<!\d)\.(?!\d)", " ", swapped)
+    swapped = re.sub(r"\.\.+", " ", swapped)
+    return re.sub(r"\s+", " ", swapped)
+
+
+def collapse_spaces(text: str) -> str:
+    """Normalise whitespace to single spaces and trim."""
+
+    if not text:
+        return ""
+    return patterns.WHITESPACE_RE.sub(" ", text).strip()
+
+
+def drop_bracketed_tags(text: str) -> str:
+    """Remove bracketed metadata tokens recognised by :mod:`musicnames.patterns`."""
+
+    if not text:
+        return ""
+
+    cleaned = patterns.BRACKET_TAG_RE.sub(" ", text)
+    cleaned = _QUALITY_PATTERN.sub(" ", cleaned)
+    cleaned = re.sub(r"\s*[\(\[\{\}\]\)]\s*", " ", cleaned)
+    return collapse_spaces(cleaned)
+
+
+def normalise_candidate(text: str) -> str:
+    """Convenience helper that applies all normalisation steps."""
+
+    stripped = strip_extension(text)
+    swapped = swap_separators_for_spaces(stripped)
+    dropped = drop_bracketed_tags(swapped)
+    return collapse_spaces(dropped)
+
+
+def unique_non_empty(values: Iterable[str]) -> list[str]:
+    """Return unique, case-insensitive values preserving order."""
+
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if not value:
+            continue
+        lowered = value.lower()
+        if lowered not in seen:
+            seen.add(lowered)
+            result.append(value)
+    return result

--- a/musicnames/parse.py
+++ b/musicnames/parse.py
@@ -1,0 +1,136 @@
+"""Pure string parsing helpers that build candidate music metadata."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, MutableMapping, Sequence
+
+from . import normalize, patterns
+
+
+@dataclass
+class ParseResult:
+    artist: str | None
+    title: str | None
+    album: str | None
+    track: str | None
+    reasons: list[str]
+    raw: MutableMapping[str, object]
+
+
+def _basename(path: str) -> str:
+    candidate = path.rstrip("/\\")
+    for separator in ("/", "\\"):
+        if separator in candidate:
+            candidate = candidate.rsplit(separator, 1)[-1]
+    return candidate
+
+
+def _normalise_parent_names(parents: Iterable[str]) -> list[str]:
+    return [normalize.normalise_candidate(parent) for parent in parents]
+
+
+def _extract_track_prefix(name: str, reasons: list[str]) -> tuple[str, str | None]:
+    match = patterns.TRACK_NUMBER_RE.match(name)
+    if not match:
+        return name, None
+    track = match.group("track").strip()
+    remainder = match.group("rest").strip()
+    reasons.append("track prefix")
+    return remainder, track
+
+
+def _strip_featured_artist(text: str, reasons: list[str]) -> str:
+    if not text:
+        return text
+    if patterns.FEATURED_TOKEN_RE.search(text):
+        primary = patterns.FEATURED_TOKEN_RE.split(text, maxsplit=1)[0].strip()
+        if primary:
+            reasons.append("featured artist token")
+            return primary
+    return text
+
+
+def parse_music_name(path: str, parents: Sequence[str] | None = None) -> ParseResult:
+    """Parse *path* using *parents* to form best-guess artist/title metadata."""
+
+    parents = list(parents or [])
+    raw: MutableMapping[str, object] = {
+        "path": path,
+        "parents": parents[:],
+    }
+
+    base_name = _basename(path)
+    raw["base_name"] = base_name
+
+    stripped = normalize.strip_extension(base_name)
+    if stripped != base_name:
+        raw["stripped_name"] = stripped
+
+    swapped = normalize.swap_separators_for_spaces(stripped)
+    if swapped != stripped:
+        raw["swapped_name"] = swapped
+
+    collapsed = normalize.collapse_spaces(swapped)
+    if collapsed != swapped:
+        raw["collapsed_name"] = collapsed
+
+    cleaned = normalize.drop_bracketed_tags(collapsed)
+    raw["cleaned_name"] = cleaned
+
+    reasons: list[str] = []
+
+    cleaned, track = _extract_track_prefix(cleaned, reasons)
+
+    dash_parts = patterns.DASH_SPLIT_RE.split(cleaned, maxsplit=2)
+    dash_parts = [part.strip() for part in dash_parts if part.strip()]
+
+    artist: str | None = None
+    title: str | None = None
+
+    if len(dash_parts) >= 2:
+        artist = dash_parts[0]
+        title = " - ".join(dash_parts[1:])
+        reasons.append("dash split")
+    else:
+        title = cleaned.strip() or None
+
+    if artist:
+        artist = normalize.collapse_spaces(artist)
+        artist = _strip_featured_artist(artist, reasons)
+        if patterns.MULTI_ARTIST_SEPARATOR_RE.search(artist):
+            reasons.append("multi artist separator")
+    if title:
+        title = normalize.collapse_spaces(title)
+
+    normalised_parents = _normalise_parent_names(parents)
+    raw["normalised_parents"] = normalised_parents
+
+    album: str | None = None
+    parent_artist: str | None = None
+
+    if normalised_parents:
+        album_candidate = normalised_parents[-1]
+        if album_candidate and album_candidate.lower() != (artist or "").lower():
+            album = album_candidate
+            reasons.append("album from parent")
+
+    for candidate in reversed(normalised_parents):
+        if candidate and candidate.lower() != (album or "").lower():
+            parent_artist = candidate
+            break
+
+    if not artist and parent_artist:
+        artist = parent_artist
+        reasons.append("parent artist fallback")
+    elif artist and parent_artist and artist.lower() == parent_artist.lower():
+        reasons.append("parent artist match")
+
+    return ParseResult(
+        artist=artist or None,
+        title=title or None,
+        album=album,
+        track=track,
+        reasons=reasons,
+        raw=raw,
+    )

--- a/musicnames/patterns.py
+++ b/musicnames/patterns.py
@@ -1,0 +1,48 @@
+"""Centralised regular expression patterns for music file parsing."""
+
+from __future__ import annotations
+
+import re
+
+# Common dash characters used to separate artist and title tokens.
+DASH_SPLIT_RE = re.compile(r"\s*(?:-|–|—|―|−)\s*")
+
+# Words that usually indicate a featured artist.
+FEATURED_TOKEN_RE = re.compile(
+    r"\b(?:feat(?:\.|uring)?|ft\.|with|vs\.|x)\b",
+    re.IGNORECASE,
+)
+
+# Separators that imply multiple artists are listed in the same field.
+MULTI_ARTIST_SEPARATOR_RE = re.compile(
+    r"\s*(?:,|&|\band\b|/|\\|\+|\s+x\s+|\s+vs\.?\s+)\s*",
+    re.IGNORECASE,
+)
+
+# Leading track numbers (optionally prefixed by disc indicators) followed by punctuation.
+TRACK_NUMBER_RE = re.compile(
+    r"^(?P<track>(?:disc\s*)?[A-Z]?\d{1,3})(?:[\._\-\s]+)(?P<rest>.+)$",
+    re.IGNORECASE,
+)
+
+# General bracket content detection.
+BRACKET_CONTENT_RE = re.compile(r"[\(\[\{]([^\)\]\}]+)[\)\]\}]")
+
+_BRACKET_KEYWORDS = (
+    "hq hd remaster remix mix bonus live explicit clean single album lp ep ost soundtrack official "
+    "lyrics audio visualizer radio edit original mix version instrumental acoustic demo cover extended "
+    "reissue deluxe mono stereo quality release group tag cd disc"
+).split()
+
+# Bracketed metadata that should usually be stripped from titles.
+BRACKET_TAG_RE = re.compile(
+    (
+        r"\s*[\(\[\{](?P<tag>[^\)\]\}]*?\b("
+        + "|".join(_BRACKET_KEYWORDS)
+        + r")\b[^\)\]\}]*)[\)\]\}]\s*"
+    ),
+    re.IGNORECASE,
+)
+
+# Collapsing whitespace.
+WHITESPACE_RE = re.compile(r"\s+")

--- a/musicnames/review.py
+++ b/musicnames/review.py
@@ -1,0 +1,103 @@
+"""Utilities that turn low-confidence parses into human review hints."""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+from .parse import ParseResult
+
+_DEFAULT_THRESHOLD = 0.65
+_SUFFIX_TOKENS = ("final", "copy", "master", "edit")
+
+
+def _alternate_split_suggestion(raw_name: str, parsed_reasons: Iterable[str]) -> str | None:
+    dash_count = sum(raw_name.count(dash) for dash in "-–—")
+    if dash_count > 1 and "dash split" not in parsed_reasons:
+        return "try alternate dash split"
+    return None
+
+
+def _parent_artist_suggestion(result: ParseResult) -> str | None:
+    parents = result.raw.get("normalised_parents", [])
+    if not isinstance(parents, Sequence) or not parents:
+        return None
+    target_artist = (result.artist or "").lower()
+    album = (result.album or "").lower()
+    for candidate in reversed(list(parents)):
+        if not isinstance(candidate, str) or not candidate:
+            continue
+        lowered = candidate.lower()
+        if lowered == target_artist or lowered == album:
+            continue
+        return f"use parent folder artist '{candidate}'"
+    return None
+
+
+def _ignore_suffix_suggestion(raw_name: str) -> str | None:
+    lowered = raw_name.lower()
+    for token in _SUFFIX_TOKENS:
+        if lowered.endswith(token):
+            return "ignore trailing suffix"
+    return None
+
+
+def _mark_unknown_suggestion(result: ParseResult) -> str | None:
+    if not result.artist or not result.title:
+        return "mark as unknown"
+    return None
+
+
+def generate_review_bundle(
+    result: ParseResult,
+    score: float,
+    score_reasons: Sequence[str] | None = None,
+    threshold: float = _DEFAULT_THRESHOLD,
+) -> dict[str, object]:
+    """Return review metadata for *result* when *score* falls below *threshold*."""
+
+    needs_review = score < threshold
+    reasons: list[str] = []
+    suggestions: list[str] = []
+
+    if not needs_review:
+        return {
+            "needs_review": False,
+            "reasons": reasons,
+            "suggestions": suggestions,
+        }
+
+    reasons.append(f"confidence {score:.2f} below {threshold:.2f}")
+
+    if score_reasons:
+        reasons.extend(score_reasons)
+
+    base_name = str(result.raw.get("base_name", ""))
+    alternate = _alternate_split_suggestion(base_name, result.reasons)
+    if alternate:
+        suggestions.append(alternate)
+
+    parent_artist = _parent_artist_suggestion(result)
+    if parent_artist:
+        suggestions.append(parent_artist)
+
+    suffix = _ignore_suffix_suggestion(base_name)
+    if suffix:
+        suggestions.append(suffix)
+
+    unknown = _mark_unknown_suggestion(result)
+    if unknown:
+        suggestions.append(unknown)
+
+    # Remove duplicate suggestions preserving order.
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for suggestion in suggestions:
+        if suggestion not in seen:
+            seen.add(suggestion)
+            deduped.append(suggestion)
+
+    return {
+        "needs_review": True,
+        "reasons": reasons,
+        "suggestions": deduped,
+    }

--- a/musicnames/score.py
+++ b/musicnames/score.py
@@ -1,0 +1,77 @@
+"""Confidence scoring utilities for parsed music names."""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+from .normalize import normalise_candidate
+from .parse import ParseResult
+
+_BASE_SCORE = 0.4
+_DASH_BONUS = 0.1
+_ARTIST_TITLE_BONUS = 0.3
+_TRACK_BONUS = 0.05
+_ALBUM_BONUS = 0.05
+_PARENT_MATCH_BONUS = 0.05
+_MISSING_FIELD_PENALTY = 0.2
+_SUSPICIOUS_ARTIST_PENALTY = 0.25
+_SUSPICIOUS_TITLE_PENALTY = 0.15
+
+_SUSPICIOUS_ARTIST_TOKENS = {"unknown", "various", "untitled"}
+_SUSPICIOUS_TITLE_TOKENS = {"track", "untitled", "unknown"}
+
+
+def _contains_token(text: str, tokens: Iterable[str]) -> bool:
+    lowered = text.lower()
+    return any(token in lowered for token in tokens)
+
+
+def score_parse_result(result: ParseResult, parents: Sequence[str] | None = None) -> tuple[float, list[str]]:
+    """Return (score, reasons) representing confidence in *result*."""
+
+    score = _BASE_SCORE
+    reasons: list[str] = ["base score"]
+
+    if result.artist and result.title:
+        score += _ARTIST_TITLE_BONUS
+        reasons.append("artist and title")
+
+    if result.track:
+        score += _TRACK_BONUS
+        reasons.append("track number")
+
+    if result.album:
+        score += _ALBUM_BONUS
+        reasons.append("album context")
+
+    if "dash split" in result.reasons:
+        score += _DASH_BONUS
+        reasons.append("dash split")
+
+    if "parent artist match" in result.reasons:
+        score += _PARENT_MATCH_BONUS
+        reasons.append("parent artist match")
+
+    if not result.artist:
+        score -= _MISSING_FIELD_PENALTY
+        reasons.append("missing artist")
+    elif _contains_token(result.artist, _SUSPICIOUS_ARTIST_TOKENS):
+        score -= _SUSPICIOUS_ARTIST_PENALTY
+        reasons.append("suspicious artist")
+
+    if not result.title:
+        score -= _MISSING_FIELD_PENALTY
+        reasons.append("missing title")
+    elif _contains_token(result.title, _SUSPICIOUS_TITLE_TOKENS):
+        score -= _SUSPICIOUS_TITLE_PENALTY
+        reasons.append("suspicious title")
+
+    if parents:
+        normalised = [normalise_candidate(parent) for parent in parents]
+        if result.artist and any(result.artist.lower() == parent.lower() for parent in normalised):
+            if "parent artist match" not in reasons:
+                reasons.append("parent artist match")
+                score += _PARENT_MATCH_BONUS
+
+    score = max(0.0, min(1.0, score))
+    return score, reasons

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)

--- a/tests/musicnames/test_normalize.py
+++ b/tests/musicnames/test_normalize.py
@@ -1,0 +1,30 @@
+import musicnames.normalize as normalize
+
+
+def test_strip_extension_handles_audio_and_suffix():
+    assert normalize.strip_extension("01-song.mp3") == "01-song"
+    assert normalize.strip_extension("recording.flac.part") == "recording"
+    assert normalize.strip_extension("notes.txt") == "notes.txt"
+
+
+def test_swap_and_collapse_spaces():
+    text = "My_Song...Final"
+    swapped = normalize.swap_separators_for_spaces(text)
+    assert swapped == "My Song Final"
+    assert normalize.collapse_spaces("  My   Song   ") == "My Song"
+
+
+def test_drop_bracketed_tags_removes_known_tokens():
+    title = "Track Name (Official Video) [1080p] {Remaster}"
+    assert normalize.drop_bracketed_tags(title) == "Track Name"
+
+
+def test_normalise_candidate_runs_all_steps():
+    raw = "01_Artist-Title (Live).mp3"
+    cleaned = normalize.normalise_candidate(raw)
+    assert cleaned == "01 Artist-Title"
+
+
+def test_unique_non_empty_preserves_order():
+    values = ["Artist", "artist", "", "Title"]
+    assert normalize.unique_non_empty(values) == ["Artist", "Title"]

--- a/tests/musicnames/test_patterns.py
+++ b/tests/musicnames/test_patterns.py
@@ -1,0 +1,29 @@
+import musicnames.patterns as patterns
+
+
+def test_dash_split_supports_common_dashes():
+    value = "Artist – Title — Remix"
+    parts = [p for p in patterns.DASH_SPLIT_RE.split(value) if p.strip()]
+    assert parts == ["Artist", "Title", "Remix"]
+
+
+def test_featured_token_detection():
+    assert patterns.FEATURED_TOKEN_RE.search("Artist feat. Guest")
+    assert patterns.FEATURED_TOKEN_RE.search("Artist x Guest")
+
+
+def test_multi_artist_separator():
+    assert patterns.MULTI_ARTIST_SEPARATOR_RE.search("Artist & Guest")
+    assert patterns.MULTI_ARTIST_SEPARATOR_RE.search("Artist, Guest")
+
+
+def test_track_number_prefix():
+    match = patterns.TRACK_NUMBER_RE.match("01 - Song Name")
+    assert match
+    assert match.group("track") == "01"
+    assert match.group("rest") == "Song Name"
+
+
+def test_bracket_tag_detection():
+    assert patterns.BRACKET_TAG_RE.search("Song (Official Video)")
+    assert not patterns.BRACKET_TAG_RE.search("Song (Piano)")

--- a/tests/musicnames/test_pipeline.py
+++ b/tests/musicnames/test_pipeline.py
@@ -1,0 +1,43 @@
+from musicnames.parse import parse_music_name
+from musicnames.score import score_parse_result
+from musicnames.review import generate_review_bundle
+
+
+def test_parse_and_score_happy_path():
+    result = parse_music_name(
+        "Artist - Song Title (Official Video).mp3",
+        parents=["Artist", "Best Album"],
+    )
+    assert result.artist == "Artist"
+    assert result.title == "Song Title"
+    assert result.album == "Best Album"
+    assert "dash split" in result.reasons
+    score, reasons = score_parse_result(result, parents=["Artist", "Best Album"])
+    assert score > 0.7
+    assert "dash split" in reasons
+    assert "artist and title" in reasons
+
+
+def test_scoring_penalises_suspicious_artist():
+    result = parse_music_name("Unknown Artist - Mystery.mp3")
+    scored, reasons = score_parse_result(result)
+    assert scored < 0.6
+    assert "suspicious artist" in reasons
+
+
+def test_review_bundle_includes_unknown_marker():
+    result = parse_music_name("Track.mp3")
+    score, score_reasons = score_parse_result(result)
+    review = generate_review_bundle(result, score, score_reasons, threshold=0.8)
+    assert review["needs_review"] is True
+    assert any("mark as unknown" in suggestion for suggestion in review["suggestions"])
+
+
+def test_review_bundle_recommends_parent_artist():
+    result = parse_music_name(
+        "Unknown - Track.mp3",
+        parents=["Artist", "Album"],
+    )
+    score, score_reasons = score_parse_result(result)
+    review = generate_review_bundle(result, score, score_reasons, threshold=0.9)
+    assert any("parent folder artist" in suggestion for suggestion in review["suggestions"])


### PR DESCRIPTION
## Summary
- add a new `musicnames` package with shared regex patterns, normalisation helpers, and a pure string parser
- score parse results with heuristic bonuses and penalties and surface review suggestions for low confidence cases
- cover normalisation, pattern handling, scoring, and review flows with dedicated unit tests

## Testing
- pytest tests/musicnames -q

------
https://chatgpt.com/codex/tasks/task_e_68e85d4174b88327982f0d44741b1d7c