### PR TITLE
Add music metadata API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Utilities for scanning large removable media libraries and keeping a SQLite-base
 - All endpoints are GET-only, paginate with `limit`/`offset`, and require an `X-API-Key` header. Missing or empty keys return `401 Unauthorized`. Defaults bind to `127.0.0.1:8756`; expanding beyond localhost or exposing the API externally is at your own risk.
 - `/v1/reports/*` mirrors the GUI summaries (`overview`, `top-extensions`, `largest-files`, `heaviest-folders`, `recent`) and clamps `limit` parameters to the configured API maximum.
 - `/v1/semantic/search` exposes the same ANN/FTS hybrid search used by the CLI. Supply `q`, optional `mode=ann|text|hybrid`, `limit`, `offset`, `drive_label`, and `hybrid=true` to tweak scoring. New maintenance routes—`GET /v1/semantic/index`, `POST /v1/semantic/index` (mode=`build|rebuild`), and `POST /v1/semantic/transcribe`—wrap the underlying pipeline with authentication and respect the `semantic.*_phase` toggles in `settings.json`.
+- `/v1/music` returns inferred music metadata for a shard with optional filters (`q`, `ext`, `min_confidence`). Responses include parsed artist/title/album/track fields plus JSON-decoded reasons and suggestions arrays. `GET /v1/music/review` exposes the manual review queue ordered by lowest confidence first.
 - Example requests:
 
   ```bash
@@ -46,6 +47,8 @@ Utilities for scanning large removable media libraries and keeping a SQLite-base
        "http://127.0.0.1:8756/v1/inventory?drive_label=MyDrive&limit=25&q=hdr"
   curl -H "X-API-Key: $VIDEOCATALOG_API_KEY" \
        "http://127.0.0.1:8756/v1/features/vector?drive_label=MyDrive&path=movies/clip.mp4&raw=true"
+  curl -H "X-API-Key: $VIDEOCATALOG_API_KEY" \
+       "http://127.0.0.1:8756/v1/music?drive_label=MyDrive&min_confidence=0.75&limit=25"
   ```
 
 - Configure behaviour under the `"api"` section of `settings.json` (host, port, API key, allowed CORS origins, default page size). Pagination caps at `max_page_size`, and `/v1/features/vector` enforces a dimensionality guard unless `?raw=true` is supplied to download large vectors explicitly.

--- a/api/models.py
+++ b/api/models.py
@@ -203,6 +203,67 @@ class DocPreviewResponse(PaginatedResponse):
     results: List[DocPreviewRow] = Field(..., description="Preview rows for this page.")
 
 
+class MusicRow(BaseModel):
+    """Single inferred music metadata row."""
+
+    path: str = Field(..., description="Inventory path for the audio file.")
+    drive_label: str = Field(..., description="Drive label owning the shard entry.")
+    ext: Optional[str] = Field(None, description="Lowercase file extension cached during the scan.")
+    artist: Optional[str] = Field(None, description="Best-effort artist parsed from the filename or folders.")
+    title: Optional[str] = Field(None, description="Best-effort track title parsed from the filename or folders.")
+    album: Optional[str] = Field(None, description="Album inferred from surrounding folders when available.")
+    track_no: Optional[str] = Field(None, description="Track number token detected in the filename or folders.")
+    confidence: float = Field(..., description="Confidence score produced by the music parser (0..1).")
+    reasons: List[str] = Field(
+        default_factory=list,
+        description="Reasons contributing to the confidence score, already sorted by relevance.",
+    )
+    suggestions: List[str] = Field(
+        default_factory=list,
+        description="Parser follow-up notes such as alternate splits or missing metadata.",
+    )
+    parsed_utc: Optional[str] = Field(
+        None, description="Timestamp (UTC) when the metadata row was generated."
+    )
+
+
+class MusicResponse(PaginatedResponse):
+    """Paginated response containing inferred music metadata."""
+
+    drive_label: str = Field(..., description="Drive label referenced by the query.")
+    results: List[MusicRow] = Field(
+        ..., description="Music metadata rows ordered by confidence then path."
+    )
+
+
+class MusicReviewEntry(BaseModel):
+    """Row queued for manual music metadata review."""
+
+    path: str = Field(..., description="Inventory path pending manual review.")
+    drive_label: str = Field(..., description="Drive label owning this queued row.")
+    ext: Optional[str] = Field(None, description="Lowercase file extension cached during the scan.")
+    confidence: float = Field(..., description="Current parser confidence score (0..1).")
+    reasons: List[str] = Field(
+        default_factory=list, description="Reasons explaining why the entry needs review."
+    )
+    suggestions: List[str] = Field(
+        default_factory=list,
+        description="Actionable suggestions to resolve the review entry.",
+    )
+    queued_utc: Optional[str] = Field(
+        None, description="Timestamp (UTC) when the entry was enqueued for review."
+    )
+
+
+class MusicReviewResponse(PaginatedResponse):
+    """Paginated response exposing the manual music review queue."""
+
+    drive_label: str = Field(..., description="Drive label referenced by the review query.")
+    results: List[MusicReviewEntry] = Field(
+        ..., description="Queued entries ordered by ascending confidence and enqueue time."
+    )
+
+
 class DrivesResponse(BaseModel):
     """Wrapper around drive list payload."""
 


### PR DESCRIPTION
## Summary
- add Pydantic schemas for music metadata rows and review entries
- extend the DataAccess layer with paginated music queries and review queue support
- expose `/v1/music` and `/v1/music/review` endpoints and document them in the README

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e90dafb80c8327a7fd535780c86026