### PR TITLE
Add visual review sampling pipeline

### DIFF
--- a/visualreview/__init__.py
+++ b/visualreview/__init__.py
@@ -1,0 +1,29 @@
+"""Visual review asset generation pipeline."""
+from __future__ import annotations
+
+from .frame_sampler import FrameSampler, FrameSamplerConfig, FrameSample
+from .contact_sheet import ContactSheetBuilder, ContactSheetConfig, ContactSheetResult
+from .store import VisualReviewStore, VisualReviewStoreConfig
+from .run import (
+    ReviewBatchResult,
+    ReviewItem,
+    ReviewProgress,
+    ReviewRunner,
+    ReviewRunnerConfig,
+)
+
+__all__ = [
+    "FrameSampler",
+    "FrameSamplerConfig",
+    "FrameSample",
+    "ContactSheetBuilder",
+    "ContactSheetConfig",
+    "ContactSheetResult",
+    "VisualReviewStore",
+    "VisualReviewStoreConfig",
+    "ReviewBatchResult",
+    "ReviewItem",
+    "ReviewProgress",
+    "ReviewRunner",
+    "ReviewRunnerConfig",
+]

--- a/visualreview/contact_sheet.py
+++ b/visualreview/contact_sheet.py
@@ -1,0 +1,189 @@
+"""Contact sheet composition utilities."""
+from __future__ import annotations
+
+import io
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+from PIL import Image, ImageOps
+
+from .frame_sampler import FrameSample
+
+
+@dataclass(slots=True)
+class ContactSheetConfig:
+    """Layout controls for contact sheet generation."""
+
+    columns: int = 4
+    max_rows: Optional[int] = None
+    cell_size: Tuple[int, int] = (320, 180)
+    background: Tuple[int, int, int] = (16, 16, 16)
+    margin: int = 24
+    padding: int = 6
+    format: str = "WEBP"
+    quality: int = 80
+    optimize: bool = True
+
+
+@dataclass(slots=True)
+class ContactSheetResult:
+    """Return payload describing the generated contact sheet."""
+
+    image: Image.Image
+    format: str
+    width: int
+    height: int
+    frame_count: int
+    optimize: bool = True
+
+    def to_bytes(self, *, quality: Optional[int] = None, format: Optional[str] = None) -> bytes:
+        buffer = io.BytesIO()
+        fmt = (format or self.format or "WEBP").upper()
+        save_kwargs = {}
+        if fmt in {"JPEG", "JPG"}:
+            save_kwargs["quality"] = int(quality or 85)
+            save_kwargs.setdefault("optimize", self.optimize)
+            save_kwargs.setdefault("progressive", True)
+        elif fmt == "WEBP":
+            save_kwargs["quality"] = int(quality or 80)
+            save_kwargs.setdefault("method", 6)
+            if self.optimize:
+                save_kwargs.setdefault("lossless", False)
+        self.image.save(buffer, format=fmt, **save_kwargs)
+        return buffer.getvalue()
+
+
+class ContactSheetBuilder:
+    """Compose a tiled preview image from sampled frames."""
+
+    def __init__(self, config: Optional[ContactSheetConfig] = None) -> None:
+        self._config = config or ContactSheetConfig()
+        self._columns = max(1, int(self._config.columns))
+        self._max_rows = (
+            max(1, int(self._config.max_rows)) if self._config.max_rows else None
+        )
+        self._cell_width = max(16, int(self._config.cell_size[0]))
+        self._cell_height = max(16, int(self._config.cell_size[1]))
+        self._background = tuple(self._config.background)
+        self._margin = max(0, int(self._config.margin))
+        self._padding = max(0, int(self._config.padding))
+        self._format = (self._config.format or "WEBP").upper()
+        self._quality = int(self._config.quality)
+        self._optimize = bool(self._config.optimize)
+
+    def build(
+        self,
+        samples: Sequence[FrameSample] | Sequence[Image.Image],
+    ) -> Optional[ContactSheetResult]:
+        frames = self._normalize_samples(samples)
+        if not frames:
+            return None
+        grid = self._layout(len(frames))
+        sheet = Image.new(
+            "RGB",
+            (
+                grid.columns * self._cell_width
+                + self._margin * 2
+                + self._padding * (grid.columns - 1),
+                grid.rows * self._cell_height
+                + self._margin * 2
+                + self._padding * (grid.rows - 1),
+            ),
+            self._background,
+        )
+        positions = self._iter_positions(grid.columns, grid.rows)
+        for frame, (x, y) in zip(frames, positions):
+            resized = ImageOps.fit(
+                frame,
+                (self._cell_width, self._cell_height),
+                method=Image.Resampling.LANCZOS,
+                centering=(0.5, 0.5),
+            )
+            offset_x = self._margin + x * (self._cell_width + self._padding)
+            offset_y = self._margin + y * (self._cell_height + self._padding)
+            sheet.paste(resized, (offset_x, offset_y))
+        return ContactSheetResult(
+            image=sheet,
+            format=self._format,
+            width=sheet.width,
+            height=sheet.height,
+            frame_count=len(frames),
+            optimize=self._optimize,
+        )
+
+    @property
+    def output_format(self) -> str:
+        return self._format
+
+    @property
+    def quality(self) -> int:
+        return self._quality
+
+    def export(
+        self,
+        samples: Sequence[FrameSample] | Sequence[Image.Image],
+        destination: Path,
+        *,
+        format: Optional[str] = None,
+        quality: Optional[int] = None,
+    ) -> Optional[ContactSheetResult]:
+        result = self.build(samples)
+        if result is None:
+            return None
+        fmt = (format or result.format or self._format).upper()
+        quality_value = quality or self._quality
+        data = result.to_bytes(quality=quality_value, format=fmt)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        with open(destination, "wb") as handle:
+            handle.write(data)
+        return ContactSheetResult(
+            image=result.image,
+            format=fmt,
+            width=result.width,
+            height=result.height,
+            frame_count=result.frame_count,
+            optimize=result.optimize,
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _normalize_samples(
+        self, samples: Sequence[FrameSample] | Sequence[Image.Image]
+    ) -> List[Image.Image]:
+        frames: List[Image.Image] = []
+        for sample in samples:
+            if isinstance(sample, FrameSample):
+                frames.append(sample.image.copy())
+            elif isinstance(sample, Image.Image):
+                frames.append(sample.copy())
+        unique: List[Image.Image] = []
+        hashes = set()
+        for frame in frames:
+            key = (frame.width, frame.height, frame.tobytes()[0:32])
+            if key in hashes:
+                continue
+            hashes.add(key)
+            unique.append(frame)
+        return unique
+
+    def _iter_positions(self, columns: int, rows: int) -> Iterable[Tuple[int, int]]:
+        for index in range(columns * rows):
+            yield index % columns, index // columns
+
+    def _layout(self, frame_count: int) -> "_Grid":
+        columns = min(self._columns, frame_count)
+        if columns <= 0:
+            columns = 1
+        rows = int(math.ceil(frame_count / columns))
+        if self._max_rows is not None:
+            rows = min(rows, self._max_rows)
+        return _Grid(columns=columns, rows=max(1, rows))
+
+
+@dataclass(slots=True)
+class _Grid:
+    columns: int
+    rows: int

--- a/visualreview/frame_sampler.py
+++ b/visualreview/frame_sampler.py
@@ -1,0 +1,453 @@
+"""Frame sampling helpers for manual visual review assets."""
+from __future__ import annotations
+
+import io
+import logging
+import math
+import subprocess
+from dataclasses import dataclass, field
+from fractions import Fraction
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+from PIL import Image
+
+from gpu.runtime import get_hwaccel_args
+
+try:  # pragma: no cover - optional dependency guard
+    import av  # type: ignore
+except Exception:  # pragma: no cover - optional dependency guard
+    av = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency guard
+    from scenedetect import SceneManager, open_video  # type: ignore
+    from scenedetect.detectors import ContentDetector  # type: ignore
+except Exception:  # pragma: no cover - optional dependency guard
+    SceneManager = None  # type: ignore
+    ContentDetector = None  # type: ignore
+    open_video = None  # type: ignore
+
+LOGGER = logging.getLogger("videocatalog.visualreview.frames")
+
+
+@dataclass(slots=True)
+class FrameSamplerConfig:
+    """Runtime configuration for :class:`FrameSampler`."""
+
+    ffmpeg_path: Optional[Path] = None
+    prefer_pyav: bool = False
+    max_frames: int = 9
+    scene_threshold: float = 27.0
+    min_scene_len: float = 24.0
+    fallback_percentages: Sequence[float] = field(
+        default_factory=lambda: (0.05, 0.20, 0.35, 0.50, 0.65, 0.80, 0.95)
+    )
+    cropdetect: bool = False
+    cropdetect_frames: int = 12
+    cropdetect_skip_seconds: float = 1.0
+    cropdetect_round: int = 16
+    hwaccel_policy: str = "AUTO"
+    allow_hwaccel: bool = True
+
+    def normalized_ffmpeg(self) -> Path:
+        if self.ffmpeg_path:
+            return Path(self.ffmpeg_path)
+        return Path("ffmpeg")
+
+
+@dataclass(slots=True)
+class FrameSample:
+    """In-memory representation of an extracted video frame."""
+
+    timestamp: float
+    image: Image.Image
+
+
+class FrameSampler:
+    """Scene-aware frame sampler with FFmpeg/PyAV backends."""
+
+    def __init__(self, config: Optional[FrameSamplerConfig] = None) -> None:
+        self._config = config or FrameSamplerConfig()
+        self._max_frames = max(1, int(self._config.max_frames))
+        self._ffmpeg_path = self._config.normalized_ffmpeg()
+        self._prefer_pyav = bool(self._config.prefer_pyav and av is not None)
+        self._percentages = [
+            float(p)
+            for p in self._config.fallback_percentages
+            if isinstance(p, (int, float))
+        ]
+        if not self._percentages:
+            self._percentages = [0.05, 0.50, 0.95]
+        self._crop_filter: Optional[str] = None
+        self._hwaccel_enabled = bool(self._config.allow_hwaccel)
+
+    def sample(self, video_path: Path, *, max_frames: Optional[int] = None) -> List[FrameSample]:
+        """Return a list of sampled frames ordered by timestamp."""
+
+        frame_budget = max(1, int(max_frames or self._max_frames))
+        timestamps = self._collect_timestamps(video_path, frame_budget)
+        if not timestamps:
+            LOGGER.debug("No timestamps determined for video: %s", video_path)
+            return []
+        if self._config.cropdetect:
+            self._crop_filter = self._detect_crop_filter(video_path)
+        samples: List[FrameSample] = []
+        extractor_order = ["pyav", "ffmpeg"] if self._prefer_pyav else ["ffmpeg", "pyav"]
+        for backend in extractor_order:
+            samples = self._extract_frames(video_path, timestamps, backend)
+            if samples:
+                break
+        if not samples:
+            LOGGER.warning("Frame extraction failed for video: %s", video_path)
+            return []
+        samples.sort(key=lambda sample: sample.timestamp)
+        if len(samples) > frame_budget:
+            samples = samples[:frame_budget]
+        return samples
+
+    # ------------------------------------------------------------------
+    # Timestamp collection helpers
+    # ------------------------------------------------------------------
+    def _collect_timestamps(self, video_path: Path, frame_budget: int) -> List[float]:
+        scenes = self._detect_scenes(video_path)
+        if scenes:
+            timestamps = self._timestamps_from_scenes(scenes, frame_budget)
+            if timestamps:
+                return timestamps
+        duration = self._probe_duration(video_path)
+        if duration:
+            values = [
+                max(0.0, min(duration, duration * pct)) for pct in self._percentages
+            ]
+            if duration > 0 and frame_budget > 0:
+                step = duration / float(frame_budget + 1)
+                for idx in range(frame_budget):
+                    pos = step * (idx + 1)
+                    values.append(max(0.0, min(duration, pos)))
+            dedup = self._deduplicate(values, frame_budget)
+            if dedup:
+                return dedup
+        fallback = [float(idx) * 2.0 for idx in range(frame_budget)]
+        return fallback[:frame_budget]
+
+    def _detect_scenes(self, video_path: Path) -> Sequence[Tuple[float, float]]:
+        if SceneManager is None or open_video is None or ContentDetector is None:
+            return []
+        try:
+            video = open_video(str(video_path))
+        except Exception:  # pragma: no cover - defensive
+            return []
+        manager = SceneManager()
+        try:
+            detector = ContentDetector(
+                threshold=float(self._config.scene_threshold),
+                min_scene_len=self._config.min_scene_len,
+            )
+        except Exception:  # pragma: no cover - fallback defaults
+            detector = ContentDetector()
+        manager.add_detector(detector)
+        try:
+            manager.detect_scenes(video)
+            scene_list = manager.get_scene_list()
+        except Exception:
+            scene_list = []
+        finally:
+            try:
+                video.close()
+            except Exception:  # pragma: no cover - best effort
+                pass
+        result: List[Tuple[float, float]] = []
+        for start_time, end_time in scene_list:
+            start_seconds = _timecode_to_seconds(start_time.timecode)
+            end_seconds = _timecode_to_seconds(end_time.timecode)
+            if math.isfinite(start_seconds) and math.isfinite(end_seconds):
+                result.append((max(0.0, start_seconds), max(0.0, end_seconds)))
+        return result
+
+    def _timestamps_from_scenes(
+        self, scenes: Sequence[Tuple[float, float]], frame_budget: int
+    ) -> List[float]:
+        timestamps: List[float] = []
+        for start, end in scenes:
+            midpoint = start + (max(end - start, 0.0) / 2.0)
+            timestamps.append(midpoint if midpoint > 0 else start)
+            if len(timestamps) >= frame_budget:
+                break
+        if timestamps:
+            return self._deduplicate(timestamps, frame_budget)
+        starts = [scene[0] for scene in scenes[:frame_budget]]
+        return self._deduplicate(starts, frame_budget)
+
+    def _deduplicate(self, values: Iterable[float], frame_budget: int) -> List[float]:
+        seen = set()
+        ordered: List[float] = []
+        for value in values:
+            rounded = round(float(value), 2)
+            if rounded in seen:
+                continue
+            seen.add(rounded)
+            ordered.append(float(value))
+            if len(ordered) >= frame_budget:
+                break
+        return ordered
+
+    # ------------------------------------------------------------------
+    # Frame extraction
+    # ------------------------------------------------------------------
+    def _extract_frames(
+        self,
+        video_path: Path,
+        timestamps: Sequence[float],
+        backend: str,
+    ) -> List[FrameSample]:
+        if backend == "pyav" and av is not None:
+            return self._extract_with_pyav(video_path, timestamps)
+        if backend == "ffmpeg":
+            return self._extract_with_ffmpeg(video_path, timestamps)
+        return []
+
+    def _extract_with_pyav(
+        self, video_path: Path, timestamps: Sequence[float]
+    ) -> List[FrameSample]:
+        if av is None:
+            return []
+        try:
+            container = av.open(str(video_path))
+        except Exception:
+            return []
+        stream = next((s for s in container.streams if s.type == "video"), None)
+        if stream is None:
+            container.close()
+            return []
+        stream.codec_context.skip_frame = "NONKEY"
+        samples: List[FrameSample] = []
+        try:
+            for ts in timestamps:
+                frame = self._decode_pyav_frame(container, stream, ts)
+                if frame is None:
+                    continue
+                image = frame.to_image()
+                if self._crop_filter:
+                    image = _apply_crop(image, self._crop_filter)
+                samples.append(FrameSample(timestamp=float(ts), image=image))
+                if len(samples) >= self._max_frames:
+                    break
+        finally:
+            container.close()
+        return samples
+
+    def _decode_pyav_frame(self, container, stream, timestamp: float):  # type: ignore[no-untyped-def]
+        seek_time = int(timestamp / stream.time_base) if stream.time_base else None
+        if seek_time is not None:
+            try:
+                container.seek(seek_time, stream=stream, any_frame=False, backward=True)
+            except Exception:
+                pass
+        target_sec = float(timestamp)
+        best_frame = None
+        min_delta = float("inf")
+        try:
+            for packet in container.demux(stream):
+                for frame in packet.decode():
+                    if frame.time is None:
+                        continue
+                    frame_sec = float(frame.time)
+                    delta = abs(frame_sec - target_sec)
+                    if delta < min_delta:
+                        min_delta = delta
+                        best_frame = frame
+                        if delta <= 0.05:
+                            return frame
+                if min_delta <= 0.05:
+                    break
+        except Exception:
+            return best_frame
+        return best_frame
+
+    def _extract_with_ffmpeg(
+        self, video_path: Path, timestamps: Sequence[float]
+    ) -> List[FrameSample]:
+        hwaccel_args: List[str] = []
+        if self._hwaccel_enabled:
+            hwaccel_args = get_hwaccel_args(
+                self._config.hwaccel_policy, allow_hwaccel=self._config.allow_hwaccel
+            )
+        samples: List[FrameSample] = []
+        for ts in timestamps:
+            image = self._extract_frame_ffmpeg(video_path, ts, hwaccel_args)
+            if image is None and hwaccel_args:
+                LOGGER.debug("Retrying frame extraction without hwaccel for %s", video_path)
+                self._hwaccel_enabled = False
+                image = self._extract_frame_ffmpeg(video_path, ts, [])
+            if image is None:
+                continue
+            if self._crop_filter:
+                image = _apply_crop(image, self._crop_filter)
+            samples.append(FrameSample(timestamp=float(ts), image=image))
+            if len(samples) >= self._max_frames:
+                break
+        return samples
+
+    def _extract_frame_ffmpeg(
+        self,
+        video_path: Path,
+        timestamp: float,
+        hwaccel_args: Sequence[str],
+    ) -> Optional[Image.Image]:
+        args: List[str] = [str(self._ffmpeg_path), "-hide_banner", "-loglevel", "error"]
+        args.extend(hwaccel_args)
+        if timestamp > 0:
+            args.extend(["-ss", f"{timestamp:.3f}"])
+        args.extend(["-i", str(video_path), "-frames:v", "1"])
+        if self._crop_filter:
+            args.extend(["-vf", self._crop_filter])
+        args.extend(["-f", "image2pipe", "-vcodec", "png", "pipe:1"])
+        try:
+            completed = subprocess.run(
+                args,
+                capture_output=True,
+                check=False,
+                timeout=20,
+            )
+        except Exception as exc:  # pragma: no cover - subprocess failure
+            LOGGER.debug("FFmpeg invocation failed: %s", exc)
+            return None
+        if completed.returncode != 0 or not completed.stdout:
+            return None
+        try:
+            with Image.open(io.BytesIO(completed.stdout)) as image:
+                return image.convert("RGB")
+        except Exception:
+            return None
+
+    # ------------------------------------------------------------------
+    # Utilities
+    # ------------------------------------------------------------------
+    def _probe_duration(self, video_path: Path) -> Optional[float]:
+        probe = self._ffmpeg_path.with_name(self._ffmpeg_path.name.replace("ffmpeg", "ffprobe"))
+        if not probe.exists():
+            return None
+        args = [
+            str(probe),
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=duration",
+            "-of",
+            "csv=p=0",
+            str(video_path),
+        ]
+        try:
+            completed = subprocess.run(
+                args,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=10,
+            )
+        except Exception:  # pragma: no cover - subprocess failure
+            return None
+        output = (completed.stdout or "").strip()
+        if not output:
+            return None
+        try:
+            value = float(output.splitlines()[0])
+        except (ValueError, IndexError):
+            return None
+        if math.isfinite(value) and value > 0:
+            return value
+        return None
+
+    def _detect_crop_filter(self, video_path: Path) -> Optional[str]:
+        ffmpeg = str(self._ffmpeg_path)
+        args: List[str] = [
+            ffmpeg,
+            "-hide_banner",
+            "-loglevel",
+            "info",
+            "-ss",
+            f"{max(0.0, float(self._config.cropdetect_skip_seconds)):.2f}",
+            "-i",
+            str(video_path),
+            "-frames:v",
+            str(max(1, int(self._config.cropdetect_frames))),
+            "-vf",
+            f"cropdetect=24:{int(self._config.cropdetect_round)}:0",
+            "-f",
+            "null",
+            "-",
+        ]
+        try:
+            completed = subprocess.run(
+                args,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=20,
+            )
+        except Exception:
+            return None
+        logs = (completed.stderr or "") + "\n" + (completed.stdout or "")
+        crop_value: Optional[str] = None
+        for line in logs.splitlines():
+            line = line.strip()
+            if "crop=" not in line:
+                continue
+            marker = line.split("crop=")[-1]
+            fields = marker.split()[0]
+            if _valid_crop_filter(fields):
+                crop_value = fields
+        if crop_value:
+            LOGGER.debug("Detected crop filter %s for %s", crop_value, video_path)
+        return crop_value
+
+
+def _valid_crop_filter(text: str) -> bool:
+    parts = text.split(":")
+    if len(parts) != 4:
+        return False
+    try:
+        values = [int(part) for part in parts]
+    except ValueError:
+        return False
+    return all(value >= 0 for value in values) and values[0] > 0 and values[1] > 0
+
+
+def _apply_crop(image: Image.Image, crop_filter: str) -> Image.Image:
+    parts = crop_filter.split(":")
+    if len(parts) != 4:
+        return image
+    try:
+        width, height, x_off, y_off = (int(part) for part in parts)
+    except ValueError:
+        return image
+    box = (x_off, y_off, x_off + width, y_off + height)
+    try:
+        return image.crop(box)
+    except Exception:
+        return image
+
+
+def _timecode_to_seconds(timecode: str) -> float:
+    try:
+        hours, minutes, seconds = timecode.split(":")
+    except ValueError:
+        return 0.0
+    try:
+        sec_fraction = float(seconds)
+    except ValueError:
+        try:
+            sec_fraction = float(Fraction(seconds))
+        except Exception:
+            sec_fraction = 0.0
+    try:
+        total = (
+            int(hours) * 3600
+            + int(minutes) * 60
+            + sec_fraction
+        )
+        return float(total)
+    except ValueError:
+        return float(sec_fraction)

--- a/visualreview/run.py
+++ b/visualreview/run.py
@@ -1,0 +1,329 @@
+"""Automated visual review generation pipeline."""
+from __future__ import annotations
+
+import logging
+import sqlite3
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Dict, Iterable, Iterator, Optional, Sequence
+
+from PIL import Image
+
+from core.db import connect
+from core.paths import get_shard_db_path, get_shards_dir, resolve_working_dir
+from structure import tv_review
+
+from .contact_sheet import ContactSheetBuilder, ContactSheetConfig
+from .frame_sampler import FrameSample, FrameSampler, FrameSamplerConfig
+from .store import VisualReviewStore, VisualReviewStoreConfig
+
+LOGGER = logging.getLogger("videocatalog.visualreview.run")
+
+ProgressCallback = Callable[["ReviewProgress"], None]
+CancelCallback = Callable[[], bool]
+
+
+@dataclass(slots=True)
+class ReviewItem:
+    """Descriptor for a single review queue entry."""
+
+    drive_label: str
+    item_type: str
+    item_key: str
+    video_path: Path
+    confidence: Optional[float] = None
+
+
+@dataclass(slots=True)
+class ReviewProgress:
+    """Progress payload emitted to observers."""
+
+    processed: int = 0
+    skipped: int = 0
+    failed: int = 0
+    total_attempted: int = 0
+    last_item: Optional[ReviewItem] = None
+
+
+@dataclass(slots=True)
+class ReviewBatchResult:
+    """Summary of a review batch run."""
+
+    processed: int = 0
+    thumbnails_written: int = 0
+    sheets_written: int = 0
+    skipped: int = 0
+    failed: int = 0
+
+
+@dataclass(slots=True)
+class ReviewRunnerConfig:
+    """Runtime configuration for :class:`ReviewRunner`."""
+
+    working_dir: Path = field(default_factory=resolve_working_dir)
+    mounts: Dict[str, Path] = field(default_factory=dict)
+    shard_labels: Optional[Sequence[str]] = None
+    batch_size: int = 3
+    sleep_seconds: float = 1.0
+    thumbnail_format: str = "JPEG"
+    thumbnail_quality: int = 85
+    thumbnail_max_size: Sequence[int] = field(default_factory=lambda: (640, 360))
+    frame_sampler: FrameSamplerConfig = field(default_factory=FrameSamplerConfig)
+    contact_sheet: ContactSheetConfig = field(default_factory=ContactSheetConfig)
+    store: VisualReviewStoreConfig = field(default_factory=VisualReviewStoreConfig)
+
+
+class ReviewRunner:
+    """High level coordinator that processes review queues in batches."""
+
+    def __init__(
+        self,
+        config: Optional[ReviewRunnerConfig] = None,
+        *,
+        frame_sampler: Optional[FrameSampler] = None,
+        contact_sheet: Optional[ContactSheetBuilder] = None,
+    ) -> None:
+        self._config = config or ReviewRunnerConfig()
+        sampler_config = self._config.frame_sampler
+        if sampler_config.max_frames <= 0:
+            sampler_config.max_frames = 6
+        sheet_config = self._config.contact_sheet
+        if sheet_config.columns <= 0:
+            sheet_config.columns = 4
+        self._sampler = frame_sampler or FrameSampler(sampler_config)
+        self._sheet_builder = contact_sheet or ContactSheetBuilder(sheet_config)
+        self._store_config = self._config.store
+        self._thumbnail_format = (self._config.thumbnail_format or "JPEG").upper()
+        self._thumbnail_quality = max(1, min(self._config.thumbnail_quality, 100))
+        limit = list(self._config.thumbnail_max_size)
+        if len(limit) != 2:
+            limit = [640, 360]
+        self._thumbnail_size = (max(32, int(limit[0])), max(32, int(limit[1])))
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def run(
+        self,
+        *,
+        progress: Optional[ProgressCallback] = None,
+        cancel: Optional[CancelCallback] = None,
+    ) -> ReviewBatchResult:
+        summary = ReviewBatchResult()
+        progress_state = ReviewProgress()
+        for label, shard_path in self._iter_shards():
+            mount = self._config.mounts.get(label)
+            if mount is None:
+                LOGGER.debug("No mount path configured for drive %s; skipping", label)
+                continue
+            mount_path = Path(mount)
+            if cancel and cancel():
+                LOGGER.info("Review run cancelled before processing shard %s", label)
+                break
+            items = list(
+                self._collect_items(label, shard_path, mount_path, self._config.batch_size)
+            )
+            if not items:
+                continue
+            with VisualReviewStore(shard_path, config=self._store_config) as store:
+                for item in items:
+                    if cancel and cancel():
+                        LOGGER.info("Review run cancelled during processing of %s", item.item_key)
+                        return summary
+                    progress_state.total_attempted += 1
+                    progress_state.last_item = item
+                    try:
+                        wrote_sheet, wrote_thumb = self._process_item(store, item)
+                    except Exception as exc:  # pragma: no cover - defensive logging
+                        LOGGER.exception("Failed to process %s/%s", item.drive_label, item.item_key)
+                        summary.failed += 1
+                        progress_state.failed += 1
+                        if progress:
+                            progress(progress_state)
+                        continue
+                    if wrote_sheet or wrote_thumb:
+                        summary.processed += 1
+                        progress_state.processed += 1
+                        if wrote_sheet:
+                            summary.sheets_written += 1
+                        if wrote_thumb:
+                            summary.thumbnails_written += 1
+                    else:
+                        summary.skipped += 1
+                        progress_state.skipped += 1
+                    if progress:
+                        progress(progress_state)
+                store.cleanup()
+            if self._config.sleep_seconds > 0:
+                time.sleep(self._config.sleep_seconds)
+        return summary
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _iter_shards(self) -> Iterator[tuple[str, Path]]:
+        shards_dir = get_shards_dir(self._config.working_dir)
+        shards_dir.mkdir(parents=True, exist_ok=True)
+        labels: Iterable[str]
+        if self._config.shard_labels:
+            labels = self._config.shard_labels
+        else:
+            labels = [path.stem for path in sorted(shards_dir.glob("*.db"))]
+        for label in labels:
+            shard_path = get_shard_db_path(self._config.working_dir, label)
+            if shard_path.exists():
+                yield label, shard_path
+
+    def _collect_items(
+        self,
+        label: str,
+        shard_path: Path,
+        mount_path: Path,
+        batch_size: int,
+    ) -> Iterator[ReviewItem]:
+        produced = 0
+        for item in self._folder_items(label, shard_path, mount_path, batch_size):
+            yield item
+            produced += 1
+            if produced >= batch_size:
+                return
+        remaining = batch_size - produced
+        if remaining <= 0:
+            return
+        for item in self._tv_items(label, shard_path, mount_path, remaining):
+            yield item
+
+    def _folder_items(
+        self,
+        label: str,
+        shard_path: Path,
+        mount_path: Path,
+        batch_size: int,
+    ) -> Iterator[ReviewItem]:
+        with connect(shard_path, read_only=True, check_same_thread=False) as conn:
+            conn.row_factory = sqlite3.Row
+            try:
+                cursor = conn.execute(
+                    """
+                    SELECT folder_path, confidence
+                    FROM review_queue
+                    ORDER BY confidence ASC, created_utc ASC
+                    LIMIT ?
+                    """,
+                    (batch_size,),
+                )
+            except sqlite3.DatabaseError:
+                return
+            rows = cursor.fetchall()
+            for row in rows:
+                folder_key = row["folder_path"]
+                try:
+                    video_row = conn.execute(
+                        "SELECT main_video_path FROM folder_profile WHERE folder_path = ?",
+                        (folder_key,),
+                    ).fetchone()
+                except sqlite3.DatabaseError:
+                    continue
+                if not video_row:
+                    continue
+                main_video = video_row["main_video_path"]
+                if not main_video:
+                    continue
+                abs_video = _resolve_media_path(mount_path, main_video)
+                if not abs_video.exists():
+                    LOGGER.debug("Video missing for folder %s on %s", folder_key, label)
+                    continue
+                yield ReviewItem(
+                    drive_label=label,
+                    item_type="folder",
+                    item_key=str(folder_key),
+                    video_path=abs_video,
+                    confidence=row["confidence"],
+                )
+
+    def _tv_items(
+        self,
+        label: str,
+        shard_path: Path,
+        mount_path: Path,
+        batch_size: int,
+    ) -> Iterator[ReviewItem]:
+        with connect(shard_path, read_only=True, check_same_thread=False) as conn:
+            try:
+                rows = tv_review.list_review_queue(conn, limit=batch_size)
+            except sqlite3.DatabaseError:
+                return
+            for row in rows:
+                item_type = row["item_type"]
+                item_key = row["item_key"]
+                if item_type != tv_review.EPISODE:
+                    continue
+                try:
+                    episode_row = conn.execute(
+                        "SELECT episode_path FROM tv_episode_profile WHERE episode_path = ?",
+                        (item_key,),
+                    ).fetchone()
+                except sqlite3.DatabaseError:
+                    continue
+                if not episode_row:
+                    continue
+                episode_path = episode_row["episode_path"] or item_key
+                abs_path = _resolve_media_path(mount_path, episode_path)
+                if not abs_path.exists():
+                    LOGGER.debug("Episode video missing for %s on %s", episode_path, label)
+                    continue
+                yield ReviewItem(
+                    drive_label=label,
+                    item_type="episode",
+                    item_key=item_key,
+                    video_path=abs_path,
+                    confidence=row["confidence"],
+                )
+
+    def _process_item(
+        self, store: VisualReviewStore, item: ReviewItem
+    ) -> tuple[bool, bool]:
+        samples = self._sampler.sample(item.video_path)
+        if not samples:
+            return False, False
+        sheet_result = self._sheet_builder.build(samples)
+        if not sheet_result:
+            return False, False
+        contact_format = (sheet_result.format or self._sheet_builder.output_format).upper()
+        contact_quality = max(1, int(self._config.contact_sheet.quality))
+        sheet_bytes = sheet_result.to_bytes(quality=contact_quality, format=contact_format)
+        wrote_sheet = store.upsert_contact_sheet(
+            item_type=item.item_type,
+            item_key=item.item_key,
+            data=sheet_bytes,
+            format=contact_format,
+            width=sheet_result.width,
+            height=sheet_result.height,
+            frame_count=sheet_result.frame_count,
+        )
+        wrote_thumb = self._store_thumbnail(store, item, samples[0])
+        return wrote_sheet, wrote_thumb
+
+    def _store_thumbnail(
+        self, store: VisualReviewStore, item: ReviewItem, sample: FrameSample
+    ) -> bool:
+        image = sample.image.copy()
+        try:
+            image.thumbnail(self._thumbnail_size, Image.Resampling.LANCZOS)
+        except Exception:
+            pass
+        return store.upsert_thumbnail(
+            item_type=item.item_type,
+            item_key=item.item_key,
+            image=image,
+            format=self._thumbnail_format,
+            quality=self._thumbnail_quality,
+        )
+
+
+def _resolve_media_path(base: Path, candidate: str) -> Path:
+    path = Path(candidate)
+    if path.is_absolute():
+        return path
+    return base / path

--- a/visualreview/store.py
+++ b/visualreview/store.py
@@ -1,0 +1,267 @@
+"""Persistence helpers for visual review assets."""
+from __future__ import annotations
+
+import io
+import logging
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from PIL import Image
+
+from core.db import connect
+
+LOGGER = logging.getLogger("videocatalog.visualreview.store")
+
+
+@dataclass(slots=True)
+class VisualReviewStoreConfig:
+    """Configuration for :class:`VisualReviewStore`."""
+
+    max_thumbnail_bytes: int = 600_000
+    max_contact_sheet_bytes: int = 2_000_000
+    thumbnail_retention: int = 800
+    sheet_retention: int = 400
+
+
+class VisualReviewStore:
+    """SQLite-backed storage for thumbnails and contact sheets."""
+
+    def __init__(
+        self,
+        shard_path: Path,
+        *,
+        config: Optional[VisualReviewStoreConfig] = None,
+    ) -> None:
+        self._path = Path(shard_path)
+        self._config = config or VisualReviewStoreConfig()
+        self._conn = connect(self._path, read_only=False, check_same_thread=False)
+        self._ensure_tables()
+
+    # ------------------------------------------------------------------
+    # Context management
+    # ------------------------------------------------------------------
+    def __enter__(self) -> "VisualReviewStore":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        self.close()
+
+    def close(self) -> None:
+        try:
+            self._conn.close()
+        except Exception:  # pragma: no cover - defensive
+            pass
+
+    # ------------------------------------------------------------------
+    # Persistence API
+    # ------------------------------------------------------------------
+    def upsert_thumbnail(
+        self,
+        *,
+        item_type: str,
+        item_key: str,
+        image: Image.Image,
+        format: str,
+        quality: int,
+    ) -> bool:
+        payload = self._encode_image(image, format=format, quality=quality)
+        if payload is None:
+            return False
+        if len(payload) > self._config.max_thumbnail_bytes:
+            LOGGER.debug(
+                "Thumbnail for %s/%s exceeds cap (%s > %s bytes)",
+                item_type,
+                item_key,
+                len(payload),
+                self._config.max_thumbnail_bytes,
+            )
+            return False
+        now = _utc_now()
+        with self._conn:
+            self._conn.execute(
+                """
+                INSERT INTO review_thumbnails (
+                    item_type, item_key, width, height, format, image_blob, updated_utc
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(item_type, item_key) DO UPDATE SET
+                    width=excluded.width,
+                    height=excluded.height,
+                    format=excluded.format,
+                    image_blob=excluded.image_blob,
+                    updated_utc=excluded.updated_utc
+                """,
+                (
+                    item_type,
+                    item_key,
+                    int(image.width),
+                    int(image.height),
+                    format.upper(),
+                    sqlite3.Binary(payload),
+                    now,
+                ),
+            )
+        self._trim_table("review_thumbnails", self._config.thumbnail_retention)
+        return True
+
+    def upsert_contact_sheet(
+        self,
+        *,
+        item_type: str,
+        item_key: str,
+        data: bytes,
+        format: str,
+        width: int,
+        height: int,
+        frame_count: int,
+    ) -> bool:
+        if not data:
+            return False
+        if len(data) > self._config.max_contact_sheet_bytes:
+            LOGGER.debug(
+                "Contact sheet for %s/%s exceeds cap (%s > %s bytes)",
+                item_type,
+                item_key,
+                len(data),
+                self._config.max_contact_sheet_bytes,
+            )
+            return False
+        now = _utc_now()
+        with self._conn:
+            self._conn.execute(
+                """
+                INSERT INTO review_contact_sheets (
+                    item_type, item_key, format, width, height, frame_count, image_blob, updated_utc
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(item_type, item_key) DO UPDATE SET
+                    format=excluded.format,
+                    width=excluded.width,
+                    height=excluded.height,
+                    frame_count=excluded.frame_count,
+                    image_blob=excluded.image_blob,
+                    updated_utc=excluded.updated_utc
+                """,
+                (
+                    item_type,
+                    item_key,
+                    format.upper(),
+                    int(width),
+                    int(height),
+                    int(frame_count),
+                    sqlite3.Binary(data),
+                    now,
+                ),
+            )
+        self._trim_table("review_contact_sheets", self._config.sheet_retention)
+        return True
+
+    def cleanup(self) -> None:
+        self._trim_table("review_thumbnails", self._config.thumbnail_retention)
+        self._trim_table("review_contact_sheets", self._config.sheet_retention)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _ensure_tables(self) -> None:
+        with self._conn:
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS review_thumbnails (
+                    item_type TEXT NOT NULL,
+                    item_key TEXT NOT NULL,
+                    width INTEGER NOT NULL,
+                    height INTEGER NOT NULL,
+                    format TEXT NOT NULL,
+                    image_blob BLOB NOT NULL,
+                    updated_utc TEXT NOT NULL,
+                    PRIMARY KEY (item_type, item_key)
+                )
+                """
+            )
+            self._conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_review_thumbnails_updated
+                ON review_thumbnails(updated_utc)
+                """
+            )
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS review_contact_sheets (
+                    item_type TEXT NOT NULL,
+                    item_key TEXT NOT NULL,
+                    format TEXT NOT NULL,
+                    width INTEGER NOT NULL,
+                    height INTEGER NOT NULL,
+                    frame_count INTEGER NOT NULL,
+                    image_blob BLOB NOT NULL,
+                    updated_utc TEXT NOT NULL,
+                    PRIMARY KEY (item_type, item_key)
+                )
+                """
+            )
+            self._conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_review_contact_sheets_updated
+                ON review_contact_sheets(updated_utc)
+                """
+            )
+
+    def _trim_table(self, table: str, retain: int) -> None:
+        if retain <= 0:
+            return
+        try:
+            cursor = self._conn.execute(f"SELECT COUNT(*) FROM {table}")
+        except sqlite3.DatabaseError:
+            return
+        row = cursor.fetchone()
+        total = int(row[0]) if row else 0
+        overflow = total - retain
+        if overflow <= 0:
+            return
+        LOGGER.debug("Trimming %s rows from %s (retain=%s)", overflow, table, retain)
+        with self._conn:
+            self._conn.execute(
+                f"""
+                DELETE FROM {table}
+                WHERE rowid IN (
+                    SELECT rowid FROM {table}
+                    ORDER BY updated_utc ASC, rowid ASC
+                    LIMIT ?
+                )
+                """,
+                (overflow,),
+            )
+
+    def _encode_image(self, image: Image.Image, *, format: str, quality: int) -> Optional[bytes]:
+        fmt = (format or "JPEG").upper()
+        buffer = io.BytesIO()
+        save_image = image
+        if fmt in {"JPEG", "JPG"} and image.mode not in {"RGB", "L"}:
+            save_image = image.convert("RGB")
+        try:
+            if fmt in {"JPEG", "JPG"}:
+                save_image.save(
+                    buffer,
+                    format="JPEG",
+                    quality=max(1, min(quality, 95)),
+                    optimize=True,
+                    progressive=True,
+                )
+            elif fmt == "WEBP":
+                save_image.save(
+                    buffer,
+                    format="WEBP",
+                    quality=max(1, min(quality, 100)),
+                    method=6,
+                )
+            else:
+                save_image.save(buffer, format=fmt)
+        except OSError:
+            return None
+        return buffer.getvalue()
+
+
+def _utc_now() -> str:
+    return datetime.utcnow().replace(tzinfo=timezone.utc).isoformat()


### PR DESCRIPTION
## Summary
- add a visualreview package exporting frame sampling, contact sheet composition, storage, and orchestration helpers
- implement scene-aware frame sampling with FFmpeg/PyAV fallbacks, optional crop detection, and GPU-aware hwaccel toggling
- compose Pillow-based contact sheets, persist thumbnails/contact sheets into shard databases with retention cleanup, and batch runner integration

## Testing
- python -m compileall visualreview

------
https://chatgpt.com/codex/tasks/task_e_68e963aaa2f88327bc95acf53d7d3c9c