### PR TITLE
Add blob budget enforcement for visual review assets

### DIFF
--- a/scan_drive.py
+++ b/scan_drive.py
@@ -1457,6 +1457,29 @@ def init_db(db_path: str):
     );
     CREATE INDEX IF NOT EXISTS idx_music_review_drive ON music_review_queue(drive_label);
     CREATE INDEX IF NOT EXISTS idx_music_review_queued ON music_review_queue(queued_utc);
+    CREATE TABLE IF NOT EXISTS video_thumbs(
+        drive_label TEXT NOT NULL,
+        path TEXT NOT NULL,
+        width INTEGER NOT NULL,
+        height INTEGER NOT NULL,
+        format TEXT NOT NULL,
+        image_blob BLOB NOT NULL,
+        updated_utc TEXT NOT NULL,
+        PRIMARY KEY(drive_label, path)
+    );
+    CREATE INDEX IF NOT EXISTS idx_video_thumbs_updated ON video_thumbs(updated_utc);
+    CREATE TABLE IF NOT EXISTS contact_sheets(
+        drive_label TEXT NOT NULL,
+        path TEXT NOT NULL,
+        format TEXT NOT NULL,
+        width INTEGER NOT NULL,
+        height INTEGER NOT NULL,
+        frame_count INTEGER NOT NULL,
+        image_blob BLOB NOT NULL,
+        updated_utc TEXT NOT NULL,
+        PRIMARY KEY(drive_label, path)
+    );
+    CREATE INDEX IF NOT EXISTS idx_contact_sheets_updated ON contact_sheets(updated_utc);
     """)
     conn.commit()
     # Migrations for legacy shards

--- a/tests/test_visualreview_settings.py
+++ b/tests/test_visualreview_settings.py
@@ -12,6 +12,7 @@ def test_visualreview_settings_defaults_to_runner_config() -> None:
     assert tuple(config.thumbnail_max_size) == (settings.max_thumb_px, settings.max_thumb_px)
     assert config.contact_sheet.columns == settings.sheet_columns
     assert config.store.thumbnail_retention == settings.thumbnail_retention
+    assert config.store.max_db_blob_mb == settings.max_db_blob_mb
 
 
 def test_load_visualreview_settings_overrides() -> None:
@@ -32,6 +33,7 @@ def test_load_visualreview_settings_overrides() -> None:
             "max_contact_sheet_bytes": 54321,
             "thumbnail_retention": 42,
             "sheet_retention": 24,
+            "max_db_blob_mb": 5,
             "prefer_pyav": True,
             "allow_hwaccel": False,
             "hwaccel_policy": "CPU_ONLY",
@@ -53,6 +55,7 @@ def test_load_visualreview_settings_overrides() -> None:
     assert config.frame_sampler.hwaccel_policy == "CPU_ONLY"
     assert tuple(config.thumbnail_max_size) == (320, 320)
     assert config.store.max_thumbnail_bytes == 12345
+    assert config.store.max_db_blob_mb == 5
     assert config.contact_sheet.columns == 5
     assert config.contact_sheet.max_rows == 2
     assert list(config.shard_labels or []) == ["alpha", "beta"]

--- a/tests/test_visualreview_store.py
+++ b/tests/test_visualreview_store.py
@@ -1,0 +1,40 @@
+import sqlite3
+
+from visualreview.store import VisualReviewStore, VisualReviewStoreConfig
+
+
+def test_visualreview_store_trims_blob_budget(tmp_path) -> None:
+    db_path = tmp_path / "store.db"
+    config = VisualReviewStoreConfig(
+        max_thumbnail_bytes=1_000_000,
+        max_contact_sheet_bytes=1_000_000,
+        thumbnail_retention=10,
+        sheet_retention=10,
+        max_db_blob_mb=1,
+    )
+    with VisualReviewStore(db_path, config=config) as store:
+        for idx in range(3):
+            payload = bytes([idx % 256]) * 400_000
+            assert store.upsert_contact_sheet(
+                item_type="video",
+                item_key=f"item-{idx}",
+                data=payload,
+                format="webp",
+                width=1920,
+                height=1080,
+                frame_count=12,
+            )
+
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT item_key, LENGTH(image_blob) FROM contact_sheets ORDER BY item_key"
+        ).fetchall()
+    finally:
+        conn.close()
+
+    keys = [row[0] for row in rows]
+    total_bytes = sum(int(row[1]) for row in rows)
+
+    assert keys == ["item-1", "item-2"]
+    assert 0 < total_bytes <= 1_000_000

--- a/visualreview/run.py
+++ b/visualreview/run.py
@@ -37,6 +37,7 @@ class VisualReviewSettings:
     max_contact_sheet_bytes: int = 2_000_000
     thumbnail_retention: int = 800
     sheet_retention: int = 400
+    max_db_blob_mb: int = 256
     batch_size: int = 3
     sleep_seconds: float = 1.0
     ffmpeg_path: Optional[Path] = None
@@ -177,6 +178,7 @@ class VisualReviewSettings:
             ),
             thumbnail_retention=_get_int("thumbnail_retention", 800, minimum=0),
             sheet_retention=_get_int("sheet_retention", 400, minimum=0),
+            max_db_blob_mb=_get_int("max_db_blob_mb", 256, minimum=0),
             batch_size=_get_int("batch_size", 3, minimum=1),
             sleep_seconds=_get_float("sleep_seconds", 1.0, minimum=0.0),
             ffmpeg_path=ffmpeg_path,
@@ -240,6 +242,7 @@ class VisualReviewSettings:
             max_contact_sheet_bytes=self.max_contact_sheet_bytes,
             thumbnail_retention=self.thumbnail_retention,
             sheet_retention=self.sheet_retention,
+            max_db_blob_mb=self.max_db_blob_mb,
         )
         mounts_payload = dict(mounts or {})
         if shard_labels is not None:


### PR DESCRIPTION
## Summary
- create catalog tables for storing video thumbnails and contact sheets
- align the shard store schema with the catalog tables and enforce a blob size budget
- extend visual review settings and add tests covering the new configuration and trimming logic

## Testing
- pytest tests/test_visualreview_settings.py tests/test_visualreview_store.py


------
https://chatgpt.com/codex/tasks/task_e_68e97b43bfb88327a00ecc04d9aa3d43