### PR TITLE
Add CLI support for visual review processing

### DIFF
--- a/visualreview/__init__.py
+++ b/visualreview/__init__.py
@@ -5,6 +5,7 @@ from .frame_sampler import FrameSampler, FrameSamplerConfig, FrameSample
 from .contact_sheet import ContactSheetBuilder, ContactSheetConfig, ContactSheetResult
 from .store import VisualReviewStore, VisualReviewStoreConfig
 from .run import (
+    QueueProcessSummary,
     ReviewBatchResult,
     ReviewItem,
     ReviewProgress,
@@ -12,6 +13,7 @@ from .run import (
     ReviewRunnerConfig,
     VisualReviewSettings,
     load_visualreview_settings,
+    process_queue,
 )
 
 __all__ = [
@@ -30,4 +32,6 @@ __all__ = [
     "ReviewRunnerConfig",
     "VisualReviewSettings",
     "load_visualreview_settings",
+    "QueueProcessSummary",
+    "process_queue",
 ]


### PR DESCRIPTION
## Summary
- add CLI switches for visual review runs and gate execution by storage and GPU policy
- resolve visual review settings, mount paths, and run the queue processor with a summarized report
- expose a reusable queue summary helper in the visualreview package for CLI consumers

## Testing
- python -m py_compile scan_drive.py visualreview/run.py
- pytest tests/test_visualreview_settings.py *(fails: ModuleNotFoundError: No module named 'PIL')*


------
https://chatgpt.com/codex/tasks/task_e_68e9a0f1ed2c8327b79c37d8e674bef2