### PR TITLE
Add Windows disk marker support and drive binding tracking

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -24,6 +24,29 @@ class DriveInfo(BaseModel):
         None, description="Timestamp (UTC) of the last completed scan for this drive."
     )
     shard_path: str = Field(..., description="Absolute path to the shard SQLite database file.")
+    volume_guid: Optional[str] = Field(
+        None,
+        description="Volume GUID path (\\\\?\\Volume{GUID}\\) bound to the drive when known.",
+    )
+    volume_serial_hex: Optional[str] = Field(
+        None,
+        description="Volume serial number in hexadecimal when reported by Windows.",
+    )
+    filesystem: Optional[str] = Field(
+        None, description="Filesystem reported for the volume during the last scan."
+    )
+    marker_seen: bool = Field(
+        False,
+        description="True when a root Disk Marker was observed during the last scan.",
+    )
+    marker_last_scan_utc: Optional[str] = Field(
+        None,
+        description="Timestamp captured from the Disk Marker for the last completed scan.",
+    )
+    last_scan_usn: Optional[int] = Field(
+        None,
+        description="NTFS USN Change Journal checkpoint persisted after the last scan.",
+    )
 
 
 class PaginatedResponse(BaseModel):

--- a/core/settings.py
+++ b/core/settings.py
@@ -69,6 +69,19 @@ DEFAULT_SETTINGS: Dict[str, Any] = {
         "max_video_frames": 2,
         "prefer_ffmpeg": True,
     },
+    "disk_marker": {
+        "enable": False,
+        "filename": ".videocatalog.id",
+        "write_hidden": True,
+        "write_readonly": True,
+        "use_hmac": True,
+        "catalog_uuid": None,
+        "hmac_key": None,
+    },
+    "delta_scan": {
+        "use_ntfs_usn": True,
+        "fallback_sampling": True,
+    },
     "gpu": {
         "policy": "AUTO",
         "allow_hwaccel_video": True,

--- a/diskmark/__init__.py
+++ b/diskmark/__init__.py
@@ -1,0 +1,28 @@
+"""Disk marker helpers for VideoCatalog."""
+
+from .marker import (
+    MarkerReadResult,
+    MarkerWriteResult,
+    MarkerRuntime,
+    load_marker,
+    prepare_runtime,
+    write_marker,
+)
+from .winvol import VolumeInfo, USNJournalInfo, get_volume_info, query_usn_journal
+from .checks import compute_signature, verify_signature, MARKER_SCHEMA
+
+__all__ = [
+    "MarkerReadResult",
+    "MarkerWriteResult",
+    "MarkerRuntime",
+    "VolumeInfo",
+    "USNJournalInfo",
+    "MARKER_SCHEMA",
+    "compute_signature",
+    "verify_signature",
+    "get_volume_info",
+    "query_usn_journal",
+    "load_marker",
+    "prepare_runtime",
+    "write_marker",
+]

--- a/diskmark/checks.py
+++ b/diskmark/checks.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+MARKER_SCHEMA = 1
+
+
+def _canonical_payload(payload: Mapping[str, Any]) -> str:
+    """Return a canonical JSON string for signature computation."""
+
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True, ensure_ascii=False)
+
+
+def compute_signature(payload: Mapping[str, Any], key: bytes) -> str:
+    """Compute a base64-encoded HMAC-SHA256 signature for *payload*."""
+
+    digest = hmac.new(key, _canonical_payload(payload).encode("utf-8"), hashlib.sha256).digest()
+    return base64.b64encode(digest).decode("ascii")
+
+
+def _payload_without_sig(payload: Mapping[str, Any]) -> dict[str, Any]:
+    if isinstance(payload, dict):
+        return {k: v for k, v in payload.items() if k != "sig"}
+    return {k: payload[k] for k in payload.keys() if k != "sig"}
+
+
+def verify_signature(payload: Mapping[str, Any], key: bytes) -> bool:
+    """Return True when the embedded signature matches the payload."""
+
+    sig = payload.get("sig") if isinstance(payload, Mapping) else None
+    if not sig or not isinstance(sig, str):
+        return False
+    expected = compute_signature(_payload_without_sig(payload), key)
+    try:
+        return hmac.compare_digest(sig, expected)
+    except ValueError:  # pragma: no cover - defensive guard
+        return False
+
+
+@dataclass(slots=True)
+class MarkerValidation:
+    """Result of validating a marker payload."""
+
+    schema_ok: bool
+    signature_ok: Optional[bool]
+    reason: Optional[str] = None
+
+
+def validate_marker(payload: Mapping[str, Any], *, key: Optional[bytes]) -> MarkerValidation:
+    schema = payload.get("schema") if isinstance(payload, Mapping) else None
+    if schema != MARKER_SCHEMA:
+        return MarkerValidation(schema_ok=False, signature_ok=None, reason="schema_mismatch")
+    if key is None:
+        return MarkerValidation(schema_ok=True, signature_ok=None)
+    signature_ok = verify_signature(payload, key)
+    return MarkerValidation(schema_ok=True, signature_ok=signature_ok, reason=None if signature_ok else "sig_mismatch")

--- a/diskmark/marker.py
+++ b/diskmark/marker.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import base64
+import json
+import os
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from core.settings import update_settings
+
+from .checks import MARKER_SCHEMA, compute_signature, validate_marker
+
+try:  # pragma: no cover - best effort import
+    from api import __version__ as APP_VERSION
+except Exception:  # pragma: no cover - fallback when API package unavailable
+    APP_VERSION = "0.0.0"
+
+APP_NAME = "VideoCatalog"
+
+__all__ = [
+    "MarkerRuntime",
+    "MarkerReadResult",
+    "MarkerWriteResult",
+    "load_marker",
+    "prepare_runtime",
+    "write_marker",
+]
+
+
+@dataclass(slots=True)
+class MarkerRuntime:
+    enabled: bool
+    filename: str
+    write_hidden: bool
+    write_readonly: bool
+    use_hmac: bool
+    hmac_key: Optional[bytes]
+    catalog_uuid: Optional[str]
+    app_name: str = APP_NAME
+    app_version: str = APP_VERSION
+
+
+@dataclass(slots=True)
+class MarkerReadResult:
+    path: Path
+    exists: bool
+    content: Optional[dict[str, Any]]
+    schema_ok: bool
+    signature_ok: Optional[bool]
+    error: Optional[str] = None
+
+
+@dataclass(slots=True)
+class MarkerWriteResult:
+    path: Path
+    status: str
+    message: str
+    content: dict[str, Any]
+    written: bool
+
+
+def prepare_runtime(
+    working_dir: Path,
+    settings: Mapping[str, Any],
+    *,
+    enable_override: Optional[bool] = None,
+    filename_override: Optional[str] = None,
+) -> MarkerRuntime:
+    cfg = dict(settings.get("disk_marker") or {})
+    enabled = bool(cfg.get("enable", False))
+    if enable_override is not None:
+        enabled = bool(enable_override)
+        cfg["enable"] = enabled
+    filename = str(cfg.get("filename") or ".videocatalog.id")
+    if filename_override:
+        filename = filename_override.strip()
+        if filename:
+            cfg["filename"] = filename
+    if not filename:
+        filename = ".videocatalog.id"
+    write_hidden = bool(cfg.get("write_hidden", True))
+    write_readonly = bool(cfg.get("write_readonly", True))
+    use_hmac = bool(cfg.get("use_hmac", True))
+    catalog_uuid = cfg.get("catalog_uuid")
+    hmac_b64 = cfg.get("hmac_key")
+    mutated = False
+    if enabled and not catalog_uuid:
+        catalog_uuid = str(uuid.uuid4())
+        cfg["catalog_uuid"] = catalog_uuid
+        mutated = True
+    hmac_bytes: Optional[bytes] = None
+    if use_hmac and enabled:
+        if not hmac_b64:
+            hmac_b64 = base64.b64encode(os.urandom(32)).decode("ascii")
+            cfg["hmac_key"] = hmac_b64
+            mutated = True
+        try:
+            hmac_bytes = base64.b64decode(hmac_b64.encode("ascii")) if hmac_b64 else None
+        except Exception:  # pragma: no cover - defensive guard
+            hmac_bytes = None
+    if mutated:
+        update_settings(working_dir, disk_marker=cfg)
+        if hasattr(settings, "__setitem__"):
+            try:
+                settings["disk_marker"] = cfg  # type: ignore[index]
+            except Exception:
+                pass
+    return MarkerRuntime(
+        enabled=enabled,
+        filename=filename,
+        write_hidden=write_hidden,
+        write_readonly=write_readonly,
+        use_hmac=use_hmac,
+        hmac_key=hmac_bytes,
+        catalog_uuid=catalog_uuid,
+    )
+
+
+def load_marker(path: Path, *, hmac_key: Optional[bytes]) -> MarkerReadResult:
+    if not path.exists():
+        return MarkerReadResult(path=path, exists=False, content=None, schema_ok=False, signature_ok=None)
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            content = json.load(handle)
+    except Exception as exc:
+        return MarkerReadResult(
+            path=path,
+            exists=True,
+            content=None,
+            schema_ok=False,
+            signature_ok=None,
+            error=str(exc),
+        )
+    if not isinstance(content, dict):
+        return MarkerReadResult(
+            path=path,
+            exists=True,
+            content=None,
+            schema_ok=False,
+            signature_ok=None,
+            error="invalid_format",
+        )
+    validation = validate_marker(content, key=hmac_key)
+    return MarkerReadResult(
+        path=path,
+        exists=True,
+        content=content,
+        schema_ok=validation.schema_ok,
+        signature_ok=validation.signature_ok,
+        error=validation.reason,
+    )
+
+
+def _apply_attributes(path: Path, *, hidden: bool, readonly: bool) -> None:
+    if os.name == "nt":  # pragma: win32-only
+        import ctypes
+
+        FILE_ATTRIBUTE_READONLY = 0x00000001
+        FILE_ATTRIBUTE_HIDDEN = 0x00000002
+        FILE_ATTRIBUTE_SYSTEM = 0x00000004
+
+        attrs = 0
+        if readonly:
+            attrs |= FILE_ATTRIBUTE_READONLY
+        if hidden:
+            attrs |= FILE_ATTRIBUTE_HIDDEN | FILE_ATTRIBUTE_SYSTEM
+        if attrs:
+            try:
+                ctypes.windll.kernel32.SetFileAttributesW(str(path), attrs)
+            except Exception:
+                pass
+    else:  # pragma: no cover - non-Windows fallback
+        if readonly:
+            try:
+                os.chmod(path, 0o444)
+            except OSError:
+                pass
+
+
+def write_marker(
+    root: Path,
+    runtime: MarkerRuntime,
+    *,
+    payload: Mapping[str, Any],
+) -> MarkerWriteResult:
+    target = Path(root) / runtime.filename
+    tmp = target.with_name(target.name + ".tmp")
+    data = dict(payload)
+    data["schema"] = MARKER_SCHEMA
+    if runtime.use_hmac and runtime.hmac_key:
+        data["sig"] = compute_signature({k: v for k, v in data.items() if k != "sig"}, runtime.hmac_key)
+    elif "sig" in data:
+        data.pop("sig", None)
+    existed = target.exists()
+    try:
+        with open(tmp, "w", encoding="utf-8") as handle:
+            json.dump(data, handle, ensure_ascii=False, indent=2)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, target)
+    except OSError as exc:
+        try:
+            if tmp.exists():
+                tmp.unlink()
+        except OSError:
+            pass
+        return MarkerWriteResult(
+            path=target,
+            status="error",
+            message=str(exc),
+            content=data,
+            written=False,
+        )
+    _apply_attributes(target, hidden=runtime.write_hidden, readonly=runtime.write_readonly)
+    message = "updated" if existed else "created"
+    return MarkerWriteResult(path=target, status="ok", message=message, content=data, written=True)

--- a/diskmark/winvol.py
+++ b/diskmark/winvol.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+__all__ = [
+    "FILE_SUPPORTS_USN_JOURNAL",
+    "VolumeInfo",
+    "USNJournalInfo",
+    "get_volume_info",
+    "query_usn_journal",
+]
+
+FILE_SUPPORTS_USN_JOURNAL = 0x02000000
+
+
+@dataclass(slots=True)
+class VolumeInfo:
+    """Snapshot of a Windows volume identity."""
+
+    root_path: str
+    label: Optional[str]
+    volume_guid: Optional[str]
+    volume_serial_hex: Optional[str]
+    filesystem: Optional[str]
+    flags: int
+    is_network: bool
+
+    @property
+    def supports_usn(self) -> bool:
+        return bool(self.flags & FILE_SUPPORTS_USN_JOURNAL) and not self.is_network
+
+
+@dataclass(slots=True)
+class USNJournalInfo:
+    """Read-only summary of the NTFS Change Journal."""
+
+    journal_id: int
+    first_usn: int
+    next_usn: int
+    timestamp_utc: str
+
+
+if os.name == "nt":  # pragma: win32-only
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.windll.kernel32
+
+    GetVolumePathNameW = kernel32.GetVolumePathNameW
+    GetVolumePathNameW.argtypes = [wintypes.LPCWSTR, wintypes.LPWSTR, wintypes.DWORD]
+    GetVolumePathNameW.restype = wintypes.BOOL
+
+    GetVolumeNameForVolumeMountPointW = kernel32.GetVolumeNameForVolumeMountPointW
+    GetVolumeNameForVolumeMountPointW.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.LPWSTR,
+        wintypes.DWORD,
+    ]
+    GetVolumeNameForVolumeMountPointW.restype = wintypes.BOOL
+
+    GetVolumeInformationW = kernel32.GetVolumeInformationW
+    GetVolumeInformationW.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.LPWSTR,
+        wintypes.DWORD,
+        ctypes.POINTER(wintypes.DWORD),
+        ctypes.POINTER(wintypes.DWORD),
+        ctypes.POINTER(wintypes.DWORD),
+        wintypes.LPWSTR,
+        wintypes.DWORD,
+    ]
+    GetVolumeInformationW.restype = wintypes.BOOL
+
+    CreateFileW = kernel32.CreateFileW
+    CreateFileW.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    CreateFileW.restype = wintypes.HANDLE
+
+    DeviceIoControl = kernel32.DeviceIoControl
+    DeviceIoControl.argtypes = [
+        wintypes.HANDLE,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        ctypes.POINTER(wintypes.DWORD),
+        wintypes.LPVOID,
+    ]
+    DeviceIoControl.restype = wintypes.BOOL
+
+    CloseHandle = kernel32.CloseHandle
+    CloseHandle.argtypes = [wintypes.HANDLE]
+    CloseHandle.restype = wintypes.BOOL
+
+    INVALID_HANDLE_VALUE = wintypes.HANDLE(-1).value
+    GENERIC_READ = 0x80000000
+    FILE_SHARE_READ = 0x00000001
+    FILE_SHARE_WRITE = 0x00000002
+    FILE_SHARE_DELETE = 0x00000004
+    OPEN_EXISTING = 3
+    FILE_FLAG_BACKUP_SEMANTICS = 0x02000000
+    FSCTL_QUERY_USN_JOURNAL = 0x000900f4
+
+    class USN_JOURNAL_DATA_V0(ctypes.Structure):
+        _fields_ = [
+            ("UsnJournalID", ctypes.c_uint64),
+            ("FirstUsn", ctypes.c_int64),
+            ("NextUsn", ctypes.c_int64),
+            ("LowestValidUsn", ctypes.c_int64),
+            ("MaxUsn", ctypes.c_int64),
+            ("MaximumSize", ctypes.c_uint64),
+            ("AllocationDelta", ctypes.c_uint64),
+        ]
+else:  # pragma: no cover - non-Windows fallback
+    ctypes = None  # type: ignore[assignment]
+    INVALID_HANDLE_VALUE = -1
+
+
+def _ensure_trailing_backslash(path: str) -> str:
+    if path.endswith("\\"):
+        return path
+    return path + "\\"
+
+
+def _resolve_root(path: Path) -> str:
+    resolved = Path(path).resolve()
+    anchor = resolved.anchor or str(resolved)
+    if not anchor:
+        anchor = str(resolved)
+    if os.name != "nt":
+        return anchor or "/"
+    buffer = None
+    wide_path = str(resolved)
+    if not wide_path:
+        wide_path = str(path)
+    try:  # pragma: win32-only
+        if not wide_path.endswith("\\"):
+            wide_path = wide_path + "\\"
+        buffer = ctypes.create_unicode_buffer(512)
+        if GetVolumePathNameW(wide_path, buffer, len(buffer)):
+            return _ensure_trailing_backslash(buffer.value or wide_path)
+    except Exception:
+        return _ensure_trailing_backslash(anchor or wide_path)  # type: ignore[arg-type]
+    return _ensure_trailing_backslash(anchor)
+
+
+def get_volume_info(path: Path | str) -> VolumeInfo:
+    """Return a best-effort :class:`VolumeInfo` for *path*."""
+
+    candidate = Path(path)
+    root_path = _resolve_root(candidate)
+    is_network = root_path.startswith("\\\\")
+
+    label = None
+    volume_guid = None
+    volume_serial_hex = None
+    filesystem = None
+    flags_value = 0
+
+    if os.name == "nt":  # pragma: win32-only
+        try:
+            buffer = ctypes.create_unicode_buffer(1024)
+            if GetVolumeNameForVolumeMountPointW(root_path, buffer, len(buffer)):
+                value = buffer.value
+                if value:
+                    volume_guid = _ensure_trailing_backslash(value)
+        except Exception:
+            volume_guid = None
+        serial = wintypes.DWORD(0)
+        max_component = wintypes.DWORD(0)
+        flags = wintypes.DWORD(0)
+        label_buffer = ctypes.create_unicode_buffer(261)
+        fs_buffer = ctypes.create_unicode_buffer(261)
+        try:
+            success = GetVolumeInformationW(
+                root_path,
+                label_buffer,
+                len(label_buffer),
+                ctypes.byref(serial),
+                ctypes.byref(max_component),
+                ctypes.byref(flags),
+                fs_buffer,
+                len(fs_buffer),
+            )
+        except Exception:
+            success = False
+        if success:
+            label = label_buffer.value or None
+            filesystem = fs_buffer.value or None
+            flags_value = int(flags.value)
+            volume_serial_hex = f"{int(serial.value) & 0xFFFFFFFF:08X}"
+        else:
+            label = None
+            filesystem = None
+            flags_value = 0
+            volume_serial_hex = None
+    else:  # pragma: no cover - non-Windows fallback
+        label = candidate.anchor or candidate.name or None
+        filesystem = None
+        volume_serial_hex = None
+        flags_value = 0
+        volume_guid = root_path
+
+    return VolumeInfo(
+        root_path=_ensure_trailing_backslash(root_path) if os.name == "nt" else root_path,
+        label=label,
+        volume_guid=volume_guid,
+        volume_serial_hex=volume_serial_hex,
+        filesystem=filesystem,
+        flags=flags_value,
+        is_network=is_network,
+    )
+
+
+def _open_volume_handle(volume_guid: str) -> Optional[int]:
+    if os.name != "nt":  # pragma: no cover - non-Windows fallback
+        return None
+    path = volume_guid.rstrip("\\")
+    handle = CreateFileW(
+        path,
+        GENERIC_READ,
+        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+        None,
+        OPEN_EXISTING,
+        FILE_FLAG_BACKUP_SEMANTICS,
+        None,
+    )
+    if handle == INVALID_HANDLE_VALUE:
+        return None
+    return handle
+
+
+def query_usn_journal(volume_guid: Optional[str]) -> Optional[USNJournalInfo]:
+    """Query the NTFS Change Journal for *volume_guid* in read-only mode."""
+
+    if os.name != "nt":  # pragma: no cover - non-Windows fallback
+        return None
+    if not volume_guid:
+        return None
+    handle = _open_volume_handle(volume_guid)
+    if handle is None:
+        return None
+    try:
+        data = USN_JOURNAL_DATA_V0()
+        bytes_returned = wintypes.DWORD(0)
+        success = DeviceIoControl(
+            handle,
+            FSCTL_QUERY_USN_JOURNAL,
+            None,
+            0,
+            ctypes.byref(data),
+            ctypes.sizeof(data),
+            ctypes.byref(bytes_returned),
+            None,
+        )
+        if not success:
+            return None
+        return USNJournalInfo(
+            journal_id=int(data.UsnJournalID),
+            first_usn=int(data.FirstUsn),
+            next_usn=int(data.NextUsn),
+            timestamp_utc=datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        )
+    finally:  # pragma: win32-only
+        try:
+            CloseHandle(handle)
+        except Exception:
+            pass

--- a/settings.json
+++ b/settings.json
@@ -6,6 +6,17 @@
     "max_video_frames": 2,
     "prefer_ffmpeg": true
   },
+  "disk_marker": {
+    "enable": false,
+    "filename": ".videocatalog.id",
+    "write_hidden": true,
+    "write_readonly": true,
+    "use_hmac": true
+  },
+  "delta_scan": {
+    "use_ntfs_usn": true,
+    "fallback_sampling": true
+  },
   "gpu": {
     "policy": "AUTO",
     "allow_hwaccel_video": true,


### PR DESCRIPTION
## Summary
- add the new `diskmark` helpers for preparing, signing, reading, and writing the optional Windows root Disk Marker plus volume/USN discovery utilities
- integrate disk marker and NTFS delta scan handling across the CLI scan pipeline, SQLite drive_binding updates, GUI worker/settings, and API drive listing fields
- extend default settings samples with disk marker/delta scan configuration and surface marker status in CLI/GUI feedback

## Testing
- python -m compileall diskmark scan_drive.py api
- python -m compileall DiskScannerGUI.py

------
https://chatgpt.com/codex/tasks/task_e_68e9b2ce6eb4832799bca2dc7487a71f