### PR TITLE
Add audit pack and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ Utilities for scanning large removable media libraries and keeping a SQLite-base
 - The tab renders five sections: an overview (totals, average size, and per-category counts), top extensions (by count and total bytes), largest files, heaviest folders (aggregated to the selected depth), and recent changes (files modified in the last *X* days). Column headers are clickable to sort in place.
 - Use **Export CSV…** or **Export JSON…** to dump the current result sets. CSV exports create one file per section and JSON bundles everything into a single structured document. Files land under `<working_dir>/exports/reports/` with timestamped names.
 
+## Audit pack
+
+- Open the **Audit** tab to review library health at a glance. The dashboard shows video/episode totals, confidence buckets, duplicate pairs, unresolved IDs, optional quality flags, and the most recent baseline snapshot. A delta summary highlights items added or resolved since the last baseline. Runs are fully asynchronous so the GUI remains responsive, and the export-folder link opens the latest artifacts directly in the OS file manager.
+- CLI users can trigger the same workflows with `scan_drive.py --audit` (summary), `--audit-export` (generate CSV/JSON exports), `--audit-baseline` (create a new baseline snapshot), and `--audit-delta` (compare the current catalog with the most recent baseline). Results print concise metrics in the console and reuse the working directory configured in `settings.json`.
+- Exports land under `<working_dir>/exports/audit/<timestamp>/` and include low-confidence queues (movies and episodes), probable duplicate pairs, unresolved IDs with top candidates, optional video-quality flags, and JSON reports for API health plus drive status. Baseline snapshots are stored in SQLite (`audit_baseline`) and a `baseline.json` file inside the export folder for easy sharing.
+
 ## Local read-only API
 
 - Launch the service directly with `python videocatalog_api.py --api-key <KEY>` (optional `--host`, `--port`, and repeated `--cors` flags override `settings.json`). On start the CLI prints `API listening on http://<host>:<port>` so other tools can probe it locally.

--- a/audit/__init__.py
+++ b/audit/__init__.py
@@ -1,0 +1,5 @@
+"""VideoCatalog audit utilities for read-only analysis and exports."""
+
+from .run import AuditRequest, AuditResult, run_audit_pack
+
+__all__ = ["AuditRequest", "AuditResult", "run_audit_pack"]

--- a/audit/baseline.py
+++ b/audit/baseline.py
@@ -1,0 +1,315 @@
+"""Baseline snapshot helpers for VideoCatalog audit operations."""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import sqlite3
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+from .summary import AuditSummary
+
+LOGGER = logging.getLogger("videocatalog.audit.baseline")
+
+
+@dataclass(slots=True)
+class BaselineRecord:
+    id: int
+    created_utc: str
+    totals: Dict[str, int]
+    hashes: Dict[str, Optional[str]]
+    drive_label: Optional[str] = None
+    volume_guid: Optional[str] = None
+    file_path: Optional[Path] = None
+
+    def as_dict(self) -> Dict[str, object]:
+        payload: Dict[str, object] = {
+            "id": self.id,
+            "created_utc": self.created_utc,
+            "totals": self.totals,
+            "hashes": self.hashes,
+        }
+        if self.drive_label is not None:
+            payload["drive_label"] = self.drive_label
+        if self.volume_guid is not None:
+            payload["volume_guid"] = self.volume_guid
+        if self.file_path is not None:
+            payload["file_path"] = str(self.file_path)
+        return payload
+
+
+@dataclass(slots=True)
+class AuditDelta:
+    added_videos: int = 0
+    removed_videos: int = 0
+    added_episodes: int = 0
+    removed_episodes: int = 0
+    new_low_confidence: int = 0
+    resolved_low_confidence: int = 0
+    new_low_confidence_episodes: int = 0
+    resolved_low_confidence_episodes: int = 0
+    new_duplicates: int = 0
+    resolved_duplicates: int = 0
+    new_quality_flags: int = 0
+    resolved_quality_flags: int = 0
+    changed_hashes: Tuple[str, ...] = ()
+
+    def as_dict(self) -> Dict[str, int | Tuple[str, ...]]:
+        return {
+            "added_videos": int(self.added_videos),
+            "removed_videos": int(self.removed_videos),
+            "added_episodes": int(self.added_episodes),
+            "removed_episodes": int(self.removed_episodes),
+            "new_low_confidence": int(self.new_low_confidence),
+            "resolved_low_confidence": int(self.resolved_low_confidence),
+            "new_low_confidence_episodes": int(self.new_low_confidence_episodes),
+            "resolved_low_confidence_episodes": int(self.resolved_low_confidence_episodes),
+            "new_duplicates": int(self.new_duplicates),
+            "resolved_duplicates": int(self.resolved_duplicates),
+            "new_quality_flags": int(self.new_quality_flags),
+            "resolved_quality_flags": int(self.resolved_quality_flags),
+            "changed_hashes": tuple(self.changed_hashes),
+        }
+
+
+def _now_utc() -> str:
+    return datetime.utcnow().replace(tzinfo=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def ensure_table(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS audit_baseline (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            drive_label TEXT,
+            volume_guid TEXT,
+            created_utc TEXT NOT NULL,
+            totals_json TEXT NOT NULL,
+            hashes_json TEXT NOT NULL
+        )
+        """
+    )
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    cur = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table,)
+    )
+    return cur.fetchone() is not None
+
+
+def _row_get(row: sqlite3.Row, key: str) -> Optional[object]:
+    try:
+        return row[key]
+    except (KeyError, IndexError, TypeError):
+        return None
+
+
+def _hash_query(
+    conn: sqlite3.Connection,
+    query: str,
+    *,
+    params: Tuple[object, ...] = (),
+    gentle_sleep: float = 0.01,
+) -> Optional[str]:
+    try:
+        cursor = conn.execute(query, params)
+    except sqlite3.DatabaseError as exc:
+        LOGGER.debug("Hash query failed (%s): %s", query, exc)
+        return None
+    digest = hashlib.md5()
+    while True:
+        rows = cursor.fetchmany(400)
+        if not rows:
+            break
+        for row in rows:
+            value = row[0]
+            if value is None:
+                continue
+            digest.update(str(value).encode("utf-8", "surrogateescape"))
+        if gentle_sleep:
+            time.sleep(gentle_sleep)
+    return digest.hexdigest()
+
+
+def _compute_hashes(conn: sqlite3.Connection, *, gentle_sleep: float) -> Dict[str, Optional[str]]:
+    hashes: Dict[str, Optional[str]] = {}
+    if _table_exists(conn, "folder_profile"):
+        hashes["movies"] = _hash_query(
+            conn,
+            "SELECT folder_path FROM folder_profile ORDER BY folder_path",
+            gentle_sleep=gentle_sleep,
+        )
+    if _table_exists(conn, "tv_episode_profile"):
+        hashes["episodes"] = _hash_query(
+            conn,
+            "SELECT episode_path FROM tv_episode_profile ORDER BY episode_path",
+            gentle_sleep=gentle_sleep,
+        )
+    if _table_exists(conn, "duplicate_candidates"):
+        hashes["duplicates"] = _hash_query(
+            conn,
+            "SELECT path_a || '|' || path_b FROM duplicate_candidates ORDER BY 1",
+            gentle_sleep=gentle_sleep,
+        )
+    if _table_exists(conn, "review_queue"):
+        hashes["review_queue"] = _hash_query(
+            conn,
+            "SELECT folder_path FROM review_queue ORDER BY folder_path",
+            gentle_sleep=gentle_sleep,
+        )
+    if _table_exists(conn, "tv_review_queue"):
+        hashes["tv_review_queue"] = _hash_query(
+            conn,
+            "SELECT item_key FROM tv_review_queue WHERE item_type='episode' ORDER BY item_key",
+            gentle_sleep=gentle_sleep,
+        )
+    if _table_exists(conn, "video_quality"):
+        hashes["quality_flags"] = _hash_query(
+            conn,
+            "SELECT path FROM video_quality WHERE TRIM(COALESCE(reasons_json,'')) != '' ORDER BY path",
+            gentle_sleep=gentle_sleep,
+        )
+    return hashes
+
+
+def _totals_from_summary(summary: AuditSummary) -> Dict[str, int]:
+    totals = {
+        "videos": int(summary.movies.total),
+        "episodes": int(summary.episodes.total),
+        "low_conf_movies": int(summary.review_queue.movies),
+        "low_conf_episodes": int(summary.review_queue.episodes),
+        "duplicates": int(summary.duplicate_pairs),
+        "quality_flags": int(summary.quality_flags or 0),
+        "unresolved_movies": int(summary.unresolved_movies),
+        "unresolved_episodes": int(summary.unresolved_episodes),
+    }
+    return totals
+
+
+def create_baseline(
+    conn: sqlite3.Connection,
+    *,
+    summary: AuditSummary,
+    export_dir: Optional[Path] = None,
+    drive_label: Optional[str] = None,
+    volume_guid: Optional[str] = None,
+    gentle_sleep: float = 0.01,
+) -> BaselineRecord:
+    """Persist a new baseline snapshot and optionally write it to disk."""
+
+    ensure_table(conn)
+    totals = _totals_from_summary(summary)
+    hashes = _compute_hashes(conn, gentle_sleep=gentle_sleep)
+    created = _now_utc()
+    payload_totals = json.dumps(totals)
+    payload_hashes = json.dumps(hashes)
+    cur = conn.execute(
+        """
+        INSERT INTO audit_baseline (drive_label, volume_guid, created_utc, totals_json, hashes_json)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (drive_label, volume_guid, created, payload_totals, payload_hashes),
+    )
+    baseline_id = int(cur.lastrowid or 0)
+    record = BaselineRecord(
+        id=baseline_id,
+        created_utc=created,
+        totals=totals,
+        hashes=hashes,
+        drive_label=drive_label,
+        volume_guid=volume_guid,
+    )
+    if export_dir is not None:
+        export_path = Path(export_dir) / "baseline.json"
+        with export_path.open("w", encoding="utf-8") as handle:
+            json.dump({"summary": summary.as_dict(), "baseline": record.as_dict()}, handle, indent=2)
+        LOGGER.info("Baseline snapshot stored at %s", export_path)
+        record.file_path = export_path
+    return record
+
+
+def _load_baseline_row(row: sqlite3.Row) -> BaselineRecord:
+    totals_raw = _row_get(row, "totals_json") or _row_get(row, 4)
+    hashes_raw = _row_get(row, "hashes_json") or _row_get(row, 5)
+    try:
+        totals = json.loads(totals_raw)
+    except json.JSONDecodeError:
+        totals = {}
+    try:
+        hashes = json.loads(hashes_raw)
+    except json.JSONDecodeError:
+        hashes = {}
+    return BaselineRecord(
+        id=int(_row_get(row, "id") or _row_get(row, 0) or 0),
+        created_utc=str(_row_get(row, "created_utc") or _row_get(row, 3) or ""),
+        totals={k: int(v) for k, v in totals.items() if isinstance(v, (int, float))},
+        hashes={k: (str(v) if v is not None else None) for k, v in hashes.items()},
+        drive_label=_row_get(row, "drive_label"),
+        volume_guid=_row_get(row, "volume_guid"),
+    )
+
+
+def get_latest_baseline(conn: sqlite3.Connection) -> Optional[BaselineRecord]:
+    ensure_table(conn)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        """
+        SELECT id, drive_label, volume_guid, created_utc, totals_json, hashes_json
+        FROM audit_baseline
+        ORDER BY datetime(created_utc) DESC, id DESC
+        LIMIT 1
+        """
+    ).fetchone()
+    conn.row_factory = None
+    if row is None:
+        return None
+    return _load_baseline_row(row)
+
+
+def compare_to_latest(
+    conn: sqlite3.Connection,
+    *,
+    summary: AuditSummary,
+    gentle_sleep: float = 0.01,
+) -> Tuple[Optional[BaselineRecord], Optional[AuditDelta]]:
+    ensure_table(conn)
+    latest = get_latest_baseline(conn)
+    if latest is None:
+        return None, None
+    baseline_hashes = latest.hashes
+    current_hashes = _compute_hashes(conn, gentle_sleep=gentle_sleep)
+    changed_keys = tuple(
+        key
+        for key, value in current_hashes.items()
+        if baseline_hashes.get(key) != value
+    )
+    totals = latest.totals
+    delta = AuditDelta()
+    current = _totals_from_summary(summary)
+    delta.added_videos = max(0, current["videos"] - totals.get("videos", 0))
+    delta.removed_videos = max(0, totals.get("videos", 0) - current["videos"])
+    delta.added_episodes = max(0, current["episodes"] - totals.get("episodes", 0))
+    delta.removed_episodes = max(0, totals.get("episodes", 0) - current["episodes"])
+    delta.new_low_confidence = max(0, current["low_conf_movies"] - totals.get("low_conf_movies", 0))
+    delta.resolved_low_confidence = max(0, totals.get("low_conf_movies", 0) - current["low_conf_movies"])
+    delta.new_low_confidence_episodes = max(
+        0, current["low_conf_episodes"] - totals.get("low_conf_episodes", 0)
+    )
+    delta.resolved_low_confidence_episodes = max(
+        0, totals.get("low_conf_episodes", 0) - current["low_conf_episodes"]
+    )
+    delta.new_duplicates = max(0, current["duplicates"] - totals.get("duplicates", 0))
+    delta.resolved_duplicates = max(0, totals.get("duplicates", 0) - current["duplicates"])
+    delta.new_quality_flags = max(
+        0, current["quality_flags"] - totals.get("quality_flags", 0)
+    )
+    delta.resolved_quality_flags = max(
+        0, totals.get("quality_flags", 0) - current["quality_flags"]
+    )
+    delta.changed_hashes = changed_keys
+    return latest, delta

--- a/audit/exports.py
+++ b/audit/exports.py
@@ -1,0 +1,484 @@
+"""CSV and JSON exporters for the VideoCatalog audit pack."""
+from __future__ import annotations
+
+import csv
+import json
+import logging
+import sqlite3
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, List, Optional
+
+from .summary import AuditSummary
+
+LOGGER = logging.getLogger("videocatalog.audit.exports")
+
+EXPORT_ROOT = "audit"
+
+
+def _row_value(row: sqlite3.Row, key: str) -> object:
+    try:
+        return row[key]
+    except (KeyError, IndexError, TypeError):
+        return None
+
+
+@dataclass(slots=True)
+class AuditExportResult:
+    directory: Path
+    files: List[Path] = field(default_factory=list)
+
+    def add(self, path: Path) -> None:
+        if path not in self.files:
+            self.files.append(path)
+
+
+def _timestamp_folder() -> str:
+    return datetime.utcnow().replace(tzinfo=timezone.utc).strftime("%Y%m%d-%H%M%S")
+
+
+def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
+    cur = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)
+    )
+    return cur.fetchone() is not None
+
+
+def _column_names(conn: sqlite3.Connection, table: str) -> List[str]:
+    cur = conn.execute(f"PRAGMA table_info({table})")
+    return [row[1] for row in cur.fetchall()]
+
+
+def _gentle_sleep(delay: float) -> None:
+    if delay > 0:
+        time.sleep(delay)
+
+
+def _prepare_export_dir(working_dir: Path) -> Path:
+    base = Path(working_dir, "exports", EXPORT_ROOT, _timestamp_folder())
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def _write_csv(path: Path, headers: List[str], rows: Iterable[Dict[str, object]]) -> int:
+    count = 0
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=headers, extrasaction="ignore")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+            count += 1
+    LOGGER.info("Wrote %s rows to %s", count, path)
+    return count
+
+
+def _write_json(path: Path, payload: object) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, ensure_ascii=False)
+    LOGGER.info("Wrote JSON payload to %s", path)
+
+
+def _parse_reasons(value: Optional[str]) -> str:
+    if not value:
+        return ""
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        return str(value)
+    if isinstance(parsed, list):
+        return "; ".join(str(item) for item in parsed)
+    if isinstance(parsed, dict):
+        return "; ".join(f"{key}={parsed[key]}" for key in parsed)
+    return str(parsed)
+
+
+def _format_candidates(rows: Iterable[sqlite3.Row]) -> str:
+    formatted: List[str] = []
+    for row in rows:
+        source = str(_row_value(row, "source") or "?")
+        candidate_id = str(_row_value(row, "candidate_id") or "").strip()
+        label_parts: List[str] = []
+        if source:
+            label_parts.append(source)
+        if candidate_id:
+            label_parts.append(candidate_id)
+        label = ":".join(label_parts) if label_parts else source
+        title = _row_value(row, "title")
+        year = _row_value(row, "year")
+        if title:
+            label = f"{label} {title}"
+        if year not in (None, ""):
+            label = f"{label} ({year})"
+        score = _row_value(row, "score")
+        try:
+            score_val = float(score) if score is not None else None
+        except (TypeError, ValueError):
+            score_val = None
+        if score_val is not None:
+            label = f"{label} [{score_val:.2f}]"
+        formatted.append(label.strip())
+    return "; ".join(item for item in formatted if item)
+
+
+def _fetch_candidates(
+    conn: sqlite3.Connection,
+    keys: Iterable[str],
+    *,
+    gentle_sleep: float,
+) -> Dict[str, List[sqlite3.Row]]:
+    unique = sorted({key for key in keys if key})
+    if not unique or not _table_exists(conn, "folder_candidates"):
+        return {}
+    result: Dict[str, List[sqlite3.Row]] = {}
+    conn.row_factory = sqlite3.Row
+    chunk = 200
+    for start in range(0, len(unique), chunk):
+        subset = unique[start : start + chunk]
+        placeholders = ",".join("?" for _ in subset)
+        cursor = conn.execute(
+            f"""
+            SELECT folder_path, source, candidate_id, title, year, score
+            FROM folder_candidates
+            WHERE folder_path IN ({placeholders})
+            ORDER BY folder_path, score DESC
+            """,
+            subset,
+        )
+        rows = cursor.fetchall()
+        for row in rows:
+            folder_path = row["folder_path"]
+            result.setdefault(folder_path, []).append(row)
+        _gentle_sleep(gentle_sleep)
+    conn.row_factory = None
+    return result
+
+
+def _iter_low_confidence_movies(
+    conn: sqlite3.Connection, *, gentle_sleep: float
+) -> Iterator[Dict[str, object]]:
+    if not _table_exists(conn, "review_queue"):
+        return iter(())
+    conn.row_factory = sqlite3.Row
+    cursor = conn.execute(
+        """
+        SELECT rq.folder_path, rq.confidence, rq.reasons_json,
+               fp.main_video_path, fp.parsed_title, fp.parsed_year
+        FROM review_queue AS rq
+        LEFT JOIN folder_profile AS fp ON fp.folder_path = rq.folder_path
+        ORDER BY rq.confidence ASC, rq.folder_path
+        """
+    )
+    rows = []
+    keys: List[str] = []
+    for row in cursor.fetchall():
+        rows.append(row)
+        keys.append(row["folder_path"])
+    candidates = _fetch_candidates(conn, keys, gentle_sleep=gentle_sleep)
+    for row in rows:
+        reasons = _parse_reasons(row["reasons_json"])
+        folder_path = row["folder_path"]
+        candidate_rows = candidates.get(folder_path, [])[:3]
+        yield {
+            "path": row["main_video_path"] or folder_path,
+            "confidence": f"{float(row["confidence"] or 0.0):.2f}",
+            "reasons": reasons,
+            "parsed_title": row["parsed_title"] or "",
+            "parsed_year": row["parsed_year"] or "",
+            "candidate_ids": _format_candidates(candidate_rows),
+        }
+    conn.row_factory = None
+
+
+def _iter_low_confidence_episodes(
+    conn: sqlite3.Connection, *, gentle_sleep: float
+) -> Iterator[Dict[str, object]]:
+    if not _table_exists(conn, "tv_review_queue"):
+        return iter(())
+    conn.row_factory = sqlite3.Row
+    cursor = conn.execute(
+        """
+        SELECT rq.item_key, rq.confidence, rq.reasons_json,
+               ep.parsed_title, ep.ids_json, ep.episode_path, ep.season_number,
+               ep.episode_numbers_json
+        FROM tv_review_queue AS rq
+        LEFT JOIN tv_episode_profile AS ep ON ep.episode_path = rq.item_key
+        WHERE rq.item_type = 'episode'
+        ORDER BY rq.confidence ASC, rq.item_key
+        """
+    )
+    rows = cursor.fetchall()
+    for row in rows:
+        reasons = _parse_reasons(row["reasons_json"])
+        ids_payload = row["ids_json"]
+        candidates: List[str] = []
+        if ids_payload:
+            try:
+                ids = json.loads(ids_payload)
+            except json.JSONDecodeError:
+                ids = {}
+            if isinstance(ids, dict):
+                for key in ("tmdb_series_id", "tmdb_id", "imdb_episode_id", "imdb_id"):
+                    value = ids.get(key)
+                    if value:
+                        candidates.append(f"{key}:{value}")
+        yield {
+            "path": row["episode_path"] or row["item_key"],
+            "confidence": f"{float(row["confidence"] or 0.0):.2f}",
+            "reasons": reasons,
+            "parsed_title": row["parsed_title"] or "",
+            "parsed_year": "",
+            "candidate_ids": "; ".join(candidates[:3]),
+        }
+    conn.row_factory = None
+
+
+def _iter_probable_duplicates(
+    conn: sqlite3.Connection,
+) -> Iterator[Dict[str, object]]:
+    if not _table_exists(conn, "duplicate_candidates"):
+        return iter(())
+    columns = _column_names(conn, "duplicate_candidates")
+    has_duration = "duration_delta" in columns
+    has_resolution = any(col in columns for col in ("resolution_delta", "res_delta"))
+    conn.row_factory = sqlite3.Row
+    cursor = conn.execute(
+        "SELECT * FROM duplicate_candidates ORDER BY score DESC"
+    )
+    rows = cursor.fetchall()
+    for row in rows:
+        payload = {
+            "path_a": row["path_a"],
+            "path_b": row["path_b"],
+            "score": f"{float(row["score"] or 0.0):.4f}",
+            "reason": row["reason"],
+        }
+        if has_duration:
+            payload["duration_delta"] = _row_value(row, "duration_delta")
+        if has_resolution:
+            payload["res_delta"] = _row_value(row, "resolution_delta") or _row_value(
+                row, "res_delta"
+            )
+        yield payload
+    conn.row_factory = None
+
+
+def _iter_unresolved_movies(
+    conn: sqlite3.Connection, *, gentle_sleep: float
+) -> Iterator[Dict[str, object]]:
+    if not _table_exists(conn, "folder_profile"):
+        return iter(())
+    conn.row_factory = sqlite3.Row
+    cursor = conn.execute(
+        """
+        SELECT folder_path, main_video_path, parsed_title, parsed_year,
+               assets_json, source_signals_json
+        FROM folder_profile
+        ORDER BY folder_path
+        """
+    )
+    rows = []
+    keys: List[str] = []
+    for row in cursor.fetchall():
+        rows.append(row)
+        keys.append(row["folder_path"])
+    candidates = _fetch_candidates(conn, keys, gentle_sleep=gentle_sleep)
+    for row in rows:
+        assets = row["assets_json"]
+        signals = row["source_signals_json"]
+        if _has_confirmed_ids(assets) or _has_confirmed_ids(signals):
+            continue
+        folder_path = row["folder_path"]
+        candidate_rows = candidates.get(folder_path, [])[:3]
+        yield {
+            "kind": "movie",
+            "path": row["main_video_path"] or folder_path,
+            "parsed_title": row["parsed_title"] or "",
+            "parsed_year": row["parsed_year"] or "",
+            "candidate_ids": _format_candidates(candidate_rows),
+        }
+    conn.row_factory = None
+
+
+def _has_confirmed_ids(blob: Optional[str]) -> bool:
+    if not blob:
+        return False
+    try:
+        payload = json.loads(blob)
+    except json.JSONDecodeError:
+        return False
+    if isinstance(payload, dict):
+        ids_obj = payload.get("ids") if isinstance(payload.get("ids"), dict) else payload
+        if isinstance(ids_obj, dict):
+            for key in ("tmdb", "tmdb_id", "imdb", "imdb_id", "tvdb", "tvdb_id"):
+                value = ids_obj.get(key)
+                if value:
+                    return True
+    return False
+
+
+def _iter_unresolved_episodes(
+    conn: sqlite3.Connection,
+) -> Iterator[Dict[str, object]]:
+    if not _table_exists(conn, "tv_episode_profile"):
+        return iter(())
+    conn.row_factory = sqlite3.Row
+    cursor = conn.execute(
+        """
+        SELECT episode_path, parsed_title, ids_json, season_number, episode_numbers_json
+        FROM tv_episode_profile
+        ORDER BY episode_path
+        """
+    )
+    rows = cursor.fetchall()
+    for row in rows:
+        ids_blob = row["ids_json"]
+        if _has_confirmed_ids(ids_blob):
+            continue
+        candidates: List[str] = []
+        if ids_blob:
+            try:
+                payload = json.loads(ids_blob)
+            except json.JSONDecodeError:
+                payload = {}
+            if isinstance(payload, dict):
+                for key in ("tmdb_series_id", "tmdb_id", "imdb_episode_id", "imdb_id"):
+                    value = payload.get(key)
+                    if value:
+                        candidates.append(f"{key}:{value}")
+        yield {
+            "kind": "episode",
+            "path": row["episode_path"],
+            "parsed_title": row["parsed_title"] or "",
+            "parsed_year": "",
+            "candidate_ids": "; ".join(candidates[:3]),
+        }
+    conn.row_factory = None
+
+
+def _iter_quality_flags(conn: sqlite3.Connection) -> Iterator[Dict[str, object]]:
+    if not _table_exists(conn, "video_quality"):
+        return iter(())
+    conn.row_factory = sqlite3.Row
+    cursor = conn.execute(
+        """
+        SELECT path, score, reasons_json, width, height, video_codec,
+               audio_channels_max, subs_present
+        FROM video_quality
+        ORDER BY updated_utc DESC
+        """
+    )
+    rows = cursor.fetchall()
+    for row in rows:
+        reasons = _parse_reasons(row["reasons_json"])
+        yield {
+            "path": row["path"],
+            "score": row["score"],
+            "reasons": reasons,
+            "width": row["width"],
+            "height": row["height"],
+            "vcodec": row["video_codec"],
+            "audio_max_ch": row["audio_channels_max"],
+            "subs_present": row["subs_present"],
+        }
+    conn.row_factory = None
+
+
+def export_audit_data(
+    conn: sqlite3.Connection,
+    *,
+    working_dir: Path,
+    summary: AuditSummary,
+    gentle_sleep: float = 0.02,
+) -> AuditExportResult:
+    """Export audit datasets to CSV/JSON files under the working directory."""
+
+    export_dir = _prepare_export_dir(working_dir)
+    LOGGER.info("Audit exports will be saved under %s", export_dir)
+    result = AuditExportResult(directory=export_dir)
+
+    movie_rows = list(_iter_low_confidence_movies(conn, gentle_sleep=gentle_sleep))
+    if movie_rows:
+        csv_path = export_dir / "low_confidence_movies.csv"
+        _write_csv(
+            csv_path,
+            ["path", "confidence", "reasons", "parsed_title", "parsed_year", "candidate_ids"],
+            movie_rows,
+        )
+        result.add(csv_path)
+        json_path = export_dir / "low_confidence_movies.json"
+        _write_json(json_path, movie_rows)
+        result.add(json_path)
+
+    episode_rows = list(
+        _iter_low_confidence_episodes(conn, gentle_sleep=gentle_sleep)
+    )
+    if episode_rows:
+        csv_path = export_dir / "low_confidence_episodes.csv"
+        _write_csv(
+            csv_path,
+            ["path", "confidence", "reasons", "parsed_title", "parsed_year", "candidate_ids"],
+            episode_rows,
+        )
+        result.add(csv_path)
+        json_path = export_dir / "low_confidence_episodes.json"
+        _write_json(json_path, episode_rows)
+        result.add(json_path)
+
+    duplicate_rows = list(_iter_probable_duplicates(conn))
+    if duplicate_rows:
+        csv_path = export_dir / "probable_duplicates.csv"
+        headers = ["path_a", "path_b", "score", "reason"]
+        if any("duration_delta" in row for row in duplicate_rows):
+            headers.append("duration_delta")
+        if any("res_delta" in row for row in duplicate_rows):
+            headers.append("res_delta")
+        _write_csv(csv_path, headers, duplicate_rows)
+        result.add(csv_path)
+        json_path = export_dir / "probable_duplicates.json"
+        _write_json(json_path, duplicate_rows)
+        result.add(json_path)
+
+    unresolved_rows: List[Dict[str, object]] = []
+    unresolved_rows.extend(_iter_unresolved_movies(conn, gentle_sleep=gentle_sleep))
+    unresolved_rows.extend(_iter_unresolved_episodes(conn))
+    if unresolved_rows:
+        csv_path = export_dir / "unresolved_ids.csv"
+        _write_csv(csv_path, ["kind", "path", "parsed_title", "parsed_year", "candidate_ids"], unresolved_rows)
+        result.add(csv_path)
+        json_path = export_dir / "unresolved_ids.json"
+        _write_json(json_path, unresolved_rows)
+        result.add(json_path)
+
+    quality_rows = list(_iter_quality_flags(conn))
+    if quality_rows:
+        csv_path = export_dir / "video_quality_flags.csv"
+        _write_csv(
+            csv_path,
+            [
+                "path",
+                "score",
+                "reasons",
+                "width",
+                "height",
+                "vcodec",
+                "audio_max_ch",
+                "subs_present",
+            ],
+            quality_rows,
+        )
+        result.add(csv_path)
+        json_path = export_dir / "video_quality_flags.json"
+        _write_json(json_path, quality_rows)
+        result.add(json_path)
+
+    api_path = export_dir / "api_health.json"
+    _write_json(api_path, summary.api_health or {})
+    result.add(api_path)
+
+    drives_path = export_dir / "drives.json"
+    _write_json(drives_path, summary.drives)
+    result.add(drives_path)
+
+    return result

--- a/audit/run.py
+++ b/audit/run.py
@@ -1,0 +1,181 @@
+"""Audit pack orchestration helpers."""
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional
+
+import sqlite3
+
+from core.db import connect
+
+from .baseline import (
+    AuditDelta,
+    BaselineRecord,
+    compare_to_latest,
+    create_baseline,
+    ensure_table,
+    get_latest_baseline,
+)
+from .exports import AuditExportResult, export_audit_data
+from .summary import AuditSummary, gather_summary
+
+LOGGER = logging.getLogger("videocatalog.audit.run")
+
+ProgressCallback = Callable[[str, dict], None]
+HeartbeatCallback = Callable[[str], None]
+
+
+class AuditCancelledError(RuntimeError):
+    """Raised when an audit run is cancelled by the caller."""
+
+
+@dataclass(slots=True)
+class AuditRequest:
+    export: bool = False
+    create_baseline: bool = False
+    compare_delta: bool = False
+    gentle_sleep: float = 0.02
+
+
+@dataclass(slots=True)
+class AuditResult:
+    summary: AuditSummary
+    export: Optional[AuditExportResult] = None
+    created_baseline: Optional[BaselineRecord] = None
+    latest_baseline: Optional[BaselineRecord] = None
+    delta: Optional[AuditDelta] = None
+
+
+def _timestamped_dir(base: Path) -> Path:
+    stamp = time.strftime("%Y%m%d-%H%M%S", time.gmtime())
+    path = base / stamp
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def run_audit_pack(
+    db_path: Path | str,
+    working_dir: Path,
+    request: AuditRequest,
+    *,
+    progress_cb: Optional[ProgressCallback] = None,
+    heartbeat_cb: Optional[HeartbeatCallback] = None,
+    cancellation: Optional["CancellationToken"] = None,
+) -> AuditResult:
+    """Run the audit workflow using the existing catalog database."""
+
+    from robust import CancellationToken  # local import to avoid cycles
+
+    if cancellation is not None and not isinstance(cancellation, CancellationToken):
+        raise TypeError("cancellation must be a CancellationToken or None")
+
+    def _emit(stage: str, payload: Optional[dict] = None) -> None:
+        if progress_cb:
+            progress_cb(stage, payload or {})
+
+    def _heartbeat(message: str) -> None:
+        if heartbeat_cb:
+            heartbeat_cb(message)
+
+    def _check_cancel() -> None:
+        if cancellation is not None and cancellation.is_set():
+            raise AuditCancelledError("Audit run cancelled")
+
+    LOGGER.info("Starting audit run: export=%s baseline=%s delta=%s", int(request.export), int(request.create_baseline), int(request.compare_delta))
+    conn = connect(db_path, timeout=60.0, check_same_thread=False)
+    conn.row_factory = None
+    ensure_table(conn)
+    try:
+        _check_cancel()
+        _emit("summary", {"status": "starting"})
+        summary = gather_summary(
+            conn,
+            working_dir=working_dir,
+            gentle_sleep=request.gentle_sleep,
+        )
+        _emit("summary", {"status": "done", "generated_utc": summary.generated_utc})
+        _heartbeat("summary")
+
+        latest_before = get_latest_baseline(conn)
+        delta_result: Optional[AuditDelta] = None
+        baseline_used: Optional[BaselineRecord] = latest_before
+        if request.compare_delta and latest_before is not None:
+            _check_cancel()
+            _emit("delta", {"status": "starting", "baseline": latest_before.created_utc})
+            baseline_used, delta_result = compare_to_latest(
+                conn,
+                summary=summary,
+                gentle_sleep=request.gentle_sleep,
+            )
+            _emit(
+                "delta",
+                {
+                    "status": "done",
+                    "baseline": baseline_used.created_utc if baseline_used else None,
+                    "changed": list(delta_result.changed_hashes) if delta_result else [],
+                },
+            )
+            _heartbeat("delta")
+
+        export_result: Optional[AuditExportResult] = None
+        if request.export:
+            _check_cancel()
+            _emit("export", {"status": "starting"})
+            export_result = export_audit_data(
+                conn,
+                working_dir=working_dir,
+                summary=summary,
+                gentle_sleep=request.gentle_sleep,
+            )
+            _emit(
+                "export",
+                {"status": "done", "directory": str(export_result.directory), "files": [str(p) for p in export_result.files]},
+            )
+            _heartbeat("export")
+
+        baseline_created: Optional[BaselineRecord] = None
+        if request.create_baseline:
+            _check_cancel()
+            _emit("baseline", {"status": "starting"})
+            export_dir = export_result.directory if export_result else _timestamped_dir(Path(working_dir, "exports", "audit"))
+            if export_result is None:
+                export_result = AuditExportResult(directory=export_dir)
+            baseline_created = create_baseline(
+                conn,
+                summary=summary,
+                export_dir=export_dir,
+                gentle_sleep=request.gentle_sleep,
+            )
+            if baseline_created.file_path:
+                export_result.add(baseline_created.file_path)
+            conn.commit()
+            _emit(
+                "baseline",
+                {
+                    "status": "done",
+                    "created_utc": baseline_created.created_utc,
+                    "path": str(baseline_created.file_path) if baseline_created.file_path else None,
+                },
+            )
+            _heartbeat("baseline")
+            baseline_used = baseline_created
+        elif latest_before is not None and baseline_used is None:
+            baseline_used = latest_before
+
+        result = AuditResult(
+            summary=summary,
+            export=export_result,
+            created_baseline=baseline_created,
+            latest_baseline=baseline_used,
+            delta=delta_result,
+        )
+        LOGGER.info("Audit run finished")
+        return result
+    finally:
+        try:
+            conn.close()
+        except sqlite3.Error:
+            pass

--- a/audit/summary.py
+++ b/audit/summary.py
@@ -1,0 +1,388 @@
+"""Read-only helpers to compute audit metrics from the catalog database."""
+from __future__ import annotations
+
+import json
+import logging
+import math
+import sqlite3
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+from core.settings import load_settings
+
+LOGGER = logging.getLogger("videocatalog.audit.summary")
+
+
+@dataclass(slots=True)
+class ConfidenceBreakdown:
+    total: int = 0
+    high: int = 0
+    medium: int = 0
+    low: int = 0
+
+    def as_dict(self) -> Dict[str, int]:
+        return {
+            "total": int(self.total),
+            "high": int(self.high),
+            "medium": int(self.medium),
+            "low": int(self.low),
+        }
+
+
+@dataclass(slots=True)
+class ReviewBreakdown:
+    movies: int = 0
+    episodes: int = 0
+
+    def as_dict(self) -> Dict[str, int]:
+        return {"movies": int(self.movies), "episodes": int(self.episodes)}
+
+
+@dataclass(slots=True)
+class AuditSummary:
+    generated_utc: str
+    movies: ConfidenceBreakdown = field(default_factory=ConfidenceBreakdown)
+    episodes: ConfidenceBreakdown = field(default_factory=ConfidenceBreakdown)
+    review_queue: ReviewBreakdown = field(default_factory=ReviewBreakdown)
+    duplicate_pairs: int = 0
+    unresolved_movies: int = 0
+    unresolved_episodes: int = 0
+    quality_flags: Optional[int] = None
+    api_health: Dict[str, object] = field(default_factory=dict)
+    drives: List[Dict[str, object]] = field(default_factory=list)
+
+    def as_dict(self) -> Dict[str, object]:
+        data: Dict[str, object] = {
+            "generated_utc": self.generated_utc,
+            "movies": self.movies.as_dict(),
+            "episodes": self.episodes.as_dict(),
+            "review_queue": self.review_queue.as_dict(),
+            "duplicate_pairs": int(self.duplicate_pairs),
+            "unresolved_movies": int(self.unresolved_movies),
+            "unresolved_episodes": int(self.unresolved_episodes),
+        }
+        if self.quality_flags is not None:
+            data["quality_flags"] = int(self.quality_flags)
+        if self.api_health:
+            data["api_health"] = self.api_health
+        if self.drives:
+            data["drives"] = list(self.drives)
+        return data
+
+
+def _now_utc() -> str:
+    return datetime.utcnow().replace(tzinfo=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    try:
+        cur = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table,)
+        )
+    except sqlite3.DatabaseError as exc:  # pragma: no cover - defensive
+        LOGGER.debug("PRAGMA table lookup failed for %s: %s", table, exc)
+        return False
+    return cur.fetchone() is not None
+
+
+def _load_thresholds(working_dir: Path) -> Tuple[float, float]:
+    settings = load_settings(working_dir)
+    low = 0.50
+    high = 0.80
+    if isinstance(settings, dict):
+        structure_cfg = settings.get("structure")
+        if isinstance(structure_cfg, dict):
+            try:
+                low = float(structure_cfg.get("low_threshold", low))
+            except (TypeError, ValueError):
+                pass
+            try:
+                high = float(structure_cfg.get("high_threshold", high))
+            except (TypeError, ValueError):
+                pass
+    if not math.isfinite(low):
+        low = 0.50
+    if not math.isfinite(high):
+        high = 0.80
+    if high <= low:
+        # keep a safe margin to avoid empty buckets
+        high = min(0.99, low + 0.25)
+    return max(0.0, min(low, 1.0)), max(0.0, min(high, 1.0))
+
+
+def _count(conn: sqlite3.Connection, query: str, params: Tuple[object, ...] = ()) -> int:
+    cur = conn.execute(query, params)
+    row = cur.fetchone()
+    if not row:
+        return 0
+    value = row[0]
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _gentle_chunks(cursor: sqlite3.Cursor, chunk: int = 400, delay: float = 0.01) -> Iterable[sqlite3.Row]:
+    while True:
+        rows = cursor.fetchmany(chunk)
+        if not rows:
+            break
+        for row in rows:
+            yield row
+        if delay:
+            time.sleep(delay)
+
+
+def _parse_json(value: Optional[str]) -> object:
+    if not value:
+        return None
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return None
+
+
+def _has_known_ids(payload: object) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    ids = payload.get("ids") if isinstance(payload.get("ids"), dict) else payload
+    if isinstance(ids, dict):
+        for key in ("tmdb", "tmdb_id", "themoviedb", "imdb", "imdb_id", "tvdb", "tvdb_id"):
+            val = ids.get(key)
+            if isinstance(val, (str, int)) and str(val).strip():
+                return True
+    return False
+
+
+def _collect_drive_rows(conn: sqlite3.Connection) -> List[Dict[str, object]]:
+    if not _table_exists(conn, "drive_binding"):
+        return []
+    try:
+        conn.row_factory = sqlite3.Row
+        cursor = conn.execute(
+            """
+            SELECT drive_label, volume_guid, marker_seen, marker_last_scan_utc, last_scan_utc
+            FROM drive_binding
+            ORDER BY drive_label COLLATE NOCASE
+            """
+        )
+        rows = [
+            {
+                "drive_label": row.get("drive_label"),
+                "volume_guid": row.get("volume_guid"),
+                "marker_seen": int(row.get("marker_seen") or 0),
+                "marker_last_scan_utc": row.get("marker_last_scan_utc"),
+                "last_scan_utc": row.get("last_scan_utc"),
+            }
+            for row in cursor.fetchall()
+        ]
+        return rows
+    except sqlite3.DatabaseError as exc:
+        LOGGER.warning("drive_binding query failed: %s", exc)
+        return []
+    finally:
+        conn.row_factory = None
+
+
+def _collect_api_health(conn: sqlite3.Connection) -> Dict[str, object]:
+    health: Dict[str, object] = {}
+    if not _table_exists(conn, "api_log") and not _table_exists(conn, "api_quota"):
+        return health
+    conn.row_factory = sqlite3.Row
+    try:
+        if _table_exists(conn, "api_quota"):
+            quota_rows = conn.execute(
+                "SELECT * FROM api_quota ORDER BY updated_utc DESC LIMIT 20"
+            ).fetchall()
+            quota_payload: List[Dict[str, object]] = []
+            for row in quota_rows:
+                quota_payload.append({key: row[key] for key in row.keys()})
+            if quota_payload:
+                health["quota"] = quota_payload
+        if _table_exists(conn, "api_log"):
+            log_rows = conn.execute(
+                "SELECT * FROM api_log ORDER BY created_utc DESC LIMIT 50"
+            ).fetchall()
+            providers: Dict[str, Dict[str, object]] = {}
+            errors: Dict[str, List[Dict[str, object]]] = {}
+            for row in log_rows:
+                provider = str(row.get("provider") or "misc")
+                entry = {key: row[key] for key in row.keys()}
+                if row.get("level") in ("error", "critical", "warning"):
+                    errors.setdefault(provider, []).append(entry)
+                if provider not in providers:
+                    providers[provider] = entry
+            if providers:
+                health["last_status"] = providers
+            if errors:
+                health["recent_errors"] = errors
+    except sqlite3.DatabaseError as exc:
+        LOGGER.warning("API health query failed: %s", exc)
+    finally:
+        conn.row_factory = None
+    return health
+
+
+def _count_unresolved_movies(conn: sqlite3.Connection, *, gentle_sleep: float) -> int:
+    if not _table_exists(conn, "folder_profile"):
+        return 0
+    unresolved = 0
+    try:
+        conn.row_factory = sqlite3.Row
+        cursor = conn.execute("SELECT assets_json, source_signals_json FROM folder_profile")
+        for row in _gentle_chunks(cursor, delay=gentle_sleep):
+            assets = _parse_json(row["assets_json"])
+            if _has_known_ids(assets):
+                continue
+            signals = _parse_json(row["source_signals_json"])
+            if _has_known_ids(signals):
+                continue
+            unresolved += 1
+    except sqlite3.DatabaseError as exc:
+        LOGGER.warning("Failed to inspect folder_profile IDs: %s", exc)
+    finally:
+        conn.row_factory = None
+    return unresolved
+
+
+def _count_unresolved_episodes(conn: sqlite3.Connection, *, gentle_sleep: float) -> int:
+    if not _table_exists(conn, "tv_episode_profile"):
+        return 0
+    unresolved = 0
+    try:
+        conn.row_factory = sqlite3.Row
+        cursor = conn.execute("SELECT ids_json FROM tv_episode_profile")
+        for row in _gentle_chunks(cursor, delay=gentle_sleep):
+            ids_payload = _parse_json(row["ids_json"])
+            if _has_known_ids(ids_payload):
+                continue
+            unresolved += 1
+    except sqlite3.DatabaseError as exc:
+        LOGGER.warning("Failed to inspect tv_episode_profile IDs: %s", exc)
+    finally:
+        conn.row_factory = None
+    return unresolved
+
+
+def _count_quality_flags(conn: sqlite3.Connection, *, gentle_sleep: float) -> Optional[int]:
+    if not _table_exists(conn, "video_quality"):
+        return None
+    flagged = 0
+    try:
+        conn.row_factory = sqlite3.Row
+        cursor = conn.execute("SELECT reasons_json, score FROM video_quality")
+        for row in _gentle_chunks(cursor, delay=gentle_sleep):
+            reasons = _parse_json(row["reasons_json"])
+            has_reasons = False
+            if isinstance(reasons, dict):
+                has_reasons = any(bool(v) for v in reasons.values())
+            elif isinstance(reasons, list):
+                has_reasons = bool(reasons)
+            if has_reasons:
+                flagged += 1
+                continue
+            score = row["score"]
+            try:
+                score_val = int(score) if score is not None else None
+            except (TypeError, ValueError):
+                score_val = None
+            if score_val is not None and score_val < 70:
+                flagged += 1
+    except sqlite3.DatabaseError as exc:
+        LOGGER.warning("video_quality scan failed: %s", exc)
+    finally:
+        conn.row_factory = None
+    return flagged
+
+
+def gather_summary(
+    conn: sqlite3.Connection,
+    *,
+    working_dir: Path,
+    low_threshold: Optional[float] = None,
+    high_threshold: Optional[float] = None,
+    gentle_sleep: float = 0.01,
+) -> AuditSummary:
+    """Compute high-level audit metrics from the existing catalog tables."""
+
+    low, high = _load_thresholds(working_dir)
+    if low_threshold is not None:
+        low = float(low_threshold)
+    if high_threshold is not None:
+        high = float(high_threshold)
+    summary = AuditSummary(generated_utc=_now_utc())
+
+    if _table_exists(conn, "folder_profile"):
+        summary.movies.total = _count(conn, "SELECT COUNT(*) FROM folder_profile")
+        summary.movies.high = _count(
+            conn,
+            "SELECT COUNT(*) FROM folder_profile WHERE confidence >= ?",
+            (high,),
+        )
+        summary.movies.medium = _count(
+            conn,
+            "SELECT COUNT(*) FROM folder_profile WHERE confidence >= ? AND confidence < ?",
+            (low, high),
+        )
+        summary.movies.low = _count(
+            conn,
+            "SELECT COUNT(*) FROM folder_profile WHERE confidence < ?",
+            (low,),
+        )
+    else:
+        LOGGER.info("folder_profile table missing; movie totals unavailable.")
+
+    if _table_exists(conn, "tv_episode_profile"):
+        summary.episodes.total = _count(conn, "SELECT COUNT(*) FROM tv_episode_profile")
+        summary.episodes.high = _count(
+            conn,
+            "SELECT COUNT(*) FROM tv_episode_profile WHERE confidence >= ?",
+            (high,),
+        )
+        summary.episodes.medium = _count(
+            conn,
+            (
+                "SELECT COUNT(*) FROM tv_episode_profile "
+                "WHERE confidence >= ? AND confidence < ?"
+            ),
+            (low, high),
+        )
+        summary.episodes.low = _count(
+            conn,
+            "SELECT COUNT(*) FROM tv_episode_profile WHERE confidence < ?",
+            (low,),
+        )
+    else:
+        LOGGER.info("tv_episode_profile table missing; episode totals unavailable.")
+
+    if _table_exists(conn, "review_queue"):
+        summary.review_queue.movies = _count(
+            conn, "SELECT COUNT(*) FROM review_queue"
+        )
+    if _table_exists(conn, "tv_review_queue"):
+        summary.review_queue.episodes = _count(
+            conn,
+            "SELECT COUNT(*) FROM tv_review_queue WHERE item_type='episode'",
+        )
+
+    if _table_exists(conn, "duplicate_candidates"):
+        summary.duplicate_pairs = _count(
+            conn, "SELECT COUNT(*) FROM duplicate_candidates"
+        )
+    else:
+        LOGGER.info("duplicate_candidates table missing; duplicate summary skipped.")
+
+    summary.unresolved_movies = _count_unresolved_movies(
+        conn, gentle_sleep=gentle_sleep
+    )
+    summary.unresolved_episodes = _count_unresolved_episodes(
+        conn, gentle_sleep=gentle_sleep
+    )
+    summary.quality_flags = _count_quality_flags(conn, gentle_sleep=gentle_sleep)
+    summary.api_health = _collect_api_health(conn)
+    summary.drives = _collect_drive_rows(conn)
+
+    return summary


### PR DESCRIPTION
## Summary
- add a read-only audit pack with summary, export, baseline, and orchestration modules under `audit/`
- wire the new audit workflows into the CLI, background worker, and GUI Audit tab
- document audit usage and export outputs in the README

## Testing
- python -m compileall audit DiskScannerGUI.py scan_drive.py

------
https://chatgpt.com/codex/tasks/task_e_68ea3a64c0bc8327aa64895799532845