### PR TITLE
Add local assistant with runtime, RAG, and UI

### DIFF
--- a/assistant/__init__.py
+++ b/assistant/__init__.py
@@ -1,0 +1,6 @@
+"""Assistant runtime integration for VideoCatalog."""
+
+from .service import AssistantService, AssistantStatus
+from .config import AssistantSettings
+
+__all__ = ["AssistantService", "AssistantStatus", "AssistantSettings"]

--- a/assistant/apiguard.py
+++ b/assistant/apiguard.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from pathlib import Path
+from typing import Dict, Optional
+
+import requests
+
+LOGGER = logging.getLogger("videocatalog.assistant.apiguard")
+
+
+class ApiGuard:
+    """Simple quota-aware HTTP cache for third-party APIs."""
+
+    def __init__(self, working_dir: Path, tmdb_api_key: Optional[str] = None) -> None:
+        self.cache_dir = working_dir / "cache"
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.tmdb_api_key = tmdb_api_key
+        self._lock = threading.Lock()
+        self._tmdb_cache_path = self.cache_dir / "tmdb_cache.json"
+        self._tmdb_cache: Dict[str, Dict[str, object]] = {}
+        self._tmdb_budget: Dict[str, int] = {}
+        self._load_tmdb_cache()
+
+    # ------------------------------------------------------------------
+    def tmdb_lookup(self, endpoint: str, params: Optional[Dict[str, object]] = None, *, ttl: int = 3600) -> Dict[str, object]:
+        if not self.tmdb_api_key:
+            raise RuntimeError("TMDB API key missing. Configure structure.tmdb.api_key in settings.")
+        params = dict(params or {})
+        params.setdefault("api_key", self.tmdb_api_key)
+        cache_key = json.dumps([endpoint, sorted(params.items())], sort_keys=True)
+        with self._lock:
+            cached = self._tmdb_cache.get(cache_key)
+            if cached and time.time() - cached.get("ts", 0) < ttl:
+                return cached["payload"]
+            if not self._consume_budget("tmdb", limit_per_minute=35):
+                raise RuntimeError("TMDB rate limit reached for this minute; try again later.")
+        url = f"https://api.themoviedb.org/3/{endpoint.lstrip('/')}"
+        response = requests.get(url, params=params, timeout=20)
+        response.raise_for_status()
+        payload = response.json()
+        with self._lock:
+            self._tmdb_cache[cache_key] = {"ts": time.time(), "payload": payload}
+            self._save_tmdb_cache()
+        return payload
+
+    # ------------------------------------------------------------------
+    def _load_tmdb_cache(self) -> None:
+        if not self._tmdb_cache_path.exists():
+            return
+        try:
+            payload = json.loads(self._tmdb_cache_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            LOGGER.warning("Failed to load TMDB cache: %s", exc)
+            return
+        if isinstance(payload, dict):
+            self._tmdb_cache = payload.get("entries", {})
+            self._tmdb_budget = payload.get("budget", {})
+
+    def _save_tmdb_cache(self) -> None:
+        payload = {"entries": self._tmdb_cache, "budget": self._tmdb_budget}
+        try:
+            self._tmdb_cache_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        except Exception as exc:
+            LOGGER.warning("Failed to persist TMDB cache: %s", exc)
+
+    def _consume_budget(self, bucket: str, *, limit_per_minute: int) -> bool:
+        now = int(time.time())
+        minute = now // 60
+        count = self._tmdb_budget.get(str(minute), 0)
+        if count >= limit_per_minute:
+            return False
+        self._tmdb_budget[str(minute)] = count + 1
+        # Drop stale buckets
+        for key in list(self._tmdb_budget.keys()):
+            if int(key) < minute - 5:
+                self._tmdb_budget.pop(key, None)
+        return True

--- a/assistant/config.py
+++ b/assistant/config.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Literal, Optional
+
+
+RuntimeMode = Literal["auto", "ollama", "llama_cpp", "mlc"]
+IndexBackend = Literal["faiss", "hnswlib"]
+
+
+@dataclass(slots=True)
+class RagSettings:
+    enable: bool = True
+    top_k: int = 8
+    min_score: float = 0.25
+    embed_model: str = "bge-small-en"
+    index: IndexBackend = "faiss"
+    refresh_on_start: bool = False
+
+
+@dataclass(slots=True)
+class AssistantSettings:
+    enable: bool = False
+    runtime: RuntimeMode = "auto"
+    model: str = "qwen2.5:7b-instruct"
+    ctx: int = 8192
+    temperature: float = 0.3
+    tools_enabled: bool = True
+    tool_budget: int = 20
+    rag: RagSettings = field(default_factory=RagSettings)
+
+    @classmethod
+    def from_settings(cls, payload: Dict[str, Any]) -> "AssistantSettings":
+        section = payload.get("assistant") or {}
+        rag_payload = section.get("rag") or {}
+        return cls(
+            enable=bool(section.get("enable", False)),
+            runtime=str(section.get("runtime", "auto")),
+            model=str(section.get("model", "qwen2.5:7b-instruct")),
+            ctx=int(section.get("ctx", 8192)),
+            temperature=float(section.get("temperature", 0.3)),
+            tools_enabled=bool(section.get("tools_enabled", True)),
+            tool_budget=int(section.get("tool_budget", 20)),
+            rag=RagSettings(
+                enable=bool(rag_payload.get("enable", True)),
+                top_k=int(rag_payload.get("top_k", 8)),
+                min_score=float(rag_payload.get("min_score", 0.25)),
+                embed_model=str(rag_payload.get("embed_model", "bge-small-en")),
+                index=str(rag_payload.get("index", "faiss")),
+                refresh_on_start=bool(rag_payload.get("refresh_on_start", False)),
+            ),
+        )
+
+    def to_json(self) -> Dict[str, Any]:
+        return {
+            "enable": self.enable,
+            "runtime": self.runtime,
+            "model": self.model,
+            "ctx": self.ctx,
+            "temperature": self.temperature,
+            "tools_enabled": self.tools_enabled,
+            "tool_budget": self.tool_budget,
+            "rag": {
+                "enable": self.rag.enable,
+                "top_k": self.rag.top_k,
+                "min_score": self.rag.min_score,
+                "embed_model": self.rag.embed_model,
+                "index": self.rag.index,
+                "refresh_on_start": self.rag.refresh_on_start,
+            },
+        }
+
+
+def ensure_settings_section(path: Path) -> None:
+    """Ensure ``assistant`` section exists in ``settings.json`` preserving user overrides."""
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        payload = {}
+    except Exception:
+        return
+    if "assistant" in payload:
+        return
+    payload["assistant"] = AssistantSettings().to_json()
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")

--- a/assistant/controller.py
+++ b/assistant/controller.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import Dict, List, TypedDict
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+from langgraph.graph import END, StateGraph
+
+from .llm_client import LLMClient
+from .tools import AssistantTooling, ToolBudgetExceeded
+
+LOGGER = logging.getLogger("videocatalog.assistant.controller")
+
+
+class AssistantState(TypedDict):
+    messages: List[object]
+    remaining_budget: int
+    tool_calls: List[Dict[str, object]]
+
+
+class AssistantController:
+    def __init__(self, client: LLMClient, tooling: AssistantTooling, *, system_prompt: str) -> None:
+        self.client = client
+        self.tooling = tooling
+        self.system_prompt = system_prompt
+        self.graph = self._build_graph()
+
+    def _build_graph(self):
+        workflow = StateGraph(AssistantState)
+        workflow.add_node("model", self._call_model)
+        workflow.add_node("tools", self._call_tools)
+        workflow.set_entry_point("model")
+        workflow.add_conditional_edges(
+            "model",
+            self._should_continue,
+            {"tools": "tools", "end": END},
+        )
+        workflow.add_edge("tools", "model")
+        return workflow.compile()
+
+    def run(self, history: List[object]) -> AssistantState:
+        initial_state: AssistantState = {
+            "messages": history,
+            "remaining_budget": self.tooling.budget,
+            "tool_calls": [],
+        }
+        return self.graph.invoke(initial_state)
+
+    # ------------------------------------------------------------------
+    def _call_model(self, state: AssistantState) -> AssistantState:
+        messages = state["messages"]
+        tool_defs = self._tool_schema() if self.tooling.settings.tools_enabled else []
+        response = self.client.chat(messages, tool_defs)
+        messages = messages + [response]
+        tool_calls = response.additional_kwargs.get("tool_calls") or []
+        LOGGER.debug("Assistant model returned %d tool calls", len(tool_calls))
+        return {
+            "messages": messages,
+            "remaining_budget": state["remaining_budget"],
+            "tool_calls": tool_calls,
+        }
+
+    def _should_continue(self, state: AssistantState) -> str:
+        tool_calls = state.get("tool_calls") or []
+        if not tool_calls:
+            return "end"
+        if state["remaining_budget"] <= 0:
+            LOGGER.warning("Assistant: tool budget exhausted before execution")
+            return "end"
+        return "tools"
+
+    def _call_tools(self, state: AssistantState) -> AssistantState:
+        messages = state["messages"]
+        tool_calls = state.get("tool_calls") or []
+        remaining_budget = state["remaining_budget"]
+        for call in tool_calls:
+            name = call.get("function", {}).get("name")
+            arg_json = call.get("function", {}).get("arguments", "{}")
+            try:
+                arguments = json.loads(arg_json) if isinstance(arg_json, str) else arg_json
+            except Exception as exc:
+                LOGGER.error("Invalid tool arguments: %s", exc)
+                continue
+            try:
+                result = self.tooling.execute(name, arguments)
+            except ToolBudgetExceeded as exc:
+                content = json.dumps({"error": str(exc)})
+                messages = messages + [ToolMessage(content=content, tool_call_id=call.get("id", name), name=name)]
+                remaining_budget = 0
+                break
+            except Exception as exc:
+                LOGGER.exception("Tool %s failed", name)
+                result = {"error": str(exc)}
+            content = json.dumps(result, ensure_ascii=False)
+            messages = messages + [ToolMessage(content=content, tool_call_id=call.get("id", name), name=name)]
+            remaining_budget -= 1
+        return {
+            "messages": messages,
+            "remaining_budget": remaining_budget,
+            "tool_calls": [],
+        }
+
+    def _tool_schema(self) -> List[Dict[str, object]]:
+        schema = []
+        for tool in self.tooling.definitions():
+            schema.append(
+                {
+                    "type": "function",
+                    "function": {
+                        "name": tool.name,
+                        "description": tool.description,
+                        "parameters": tool.parameters,
+                    },
+                }
+            )
+        return schema

--- a/assistant/llm_client.py
+++ b/assistant/llm_client.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import Dict, List, Optional
+
+import requests
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage, ToolMessage
+
+from .runtime import RuntimeHandle
+
+LOGGER = logging.getLogger("videocatalog.assistant.llm")
+
+
+class LLMClient:
+    def __init__(self, runtime: RuntimeHandle, model: str, *, temperature: float = 0.3, ctx: int = 8192) -> None:
+        self.runtime = runtime
+        self.model = model
+        self.temperature = temperature
+        self.ctx = ctx
+
+    def chat(self, messages: List[BaseMessage], tools: Optional[List[Dict[str, object]]] = None) -> AIMessage:
+        payload_messages = [self._to_payload(msg) for msg in messages]
+        tools_payload = tools or []
+        if self.runtime.name == "ollama":
+            response = self._chat_ollama(payload_messages, tools_payload)
+        else:
+            response = self._chat_openai(payload_messages, tools_payload)
+        return self._to_message(response)
+
+    # ------------------------------------------------------------------
+    def _chat_ollama(self, messages: List[Dict[str, object]], tools: List[Dict[str, object]]):
+        payload = {
+            "model": self.model,
+            "messages": messages,
+            "stream": False,
+            "format": "json" if not tools else None,
+            "options": {
+                "temperature": self.temperature,
+                "num_ctx": self.ctx,
+            },
+        }
+        if tools:
+            payload["tools"] = tools
+        response = requests.post(f"{self.runtime.base_url}/api/chat", json=payload, timeout=120)
+        response.raise_for_status()
+        data = response.json()
+        message = data.get("message") or {}
+        # Some Ollama builds return list of messages under "messages"
+        if not message and isinstance(data.get("messages"), list):
+            message = data["messages"][-1]
+        return message
+
+    def _chat_openai(self, messages: List[Dict[str, object]], tools: List[Dict[str, object]]):
+        payload = {
+            "model": self.model,
+            "messages": messages,
+            "temperature": self.temperature,
+            "stream": False,
+            "max_tokens": 1024,
+        }
+        if tools:
+            payload["tools"] = tools
+            payload["tool_choice"] = "auto"
+        response = requests.post(
+            f"{self.runtime.base_url}/v1/chat/completions",
+            json=payload,
+            timeout=120,
+        )
+        response.raise_for_status()
+        data = response.json()
+        choices = data.get("choices") or []
+        if not choices:
+            raise RuntimeError("LLM returned no choices")
+        return choices[0].get("message", {})
+
+    # ------------------------------------------------------------------
+    def _to_message(self, payload: Dict[str, object]) -> AIMessage:
+        tool_calls = payload.get("tool_calls") or []
+        if not tool_calls and isinstance(payload.get("content"), str):
+            parsed = self._try_parse_tool_call(payload["content"])
+            if parsed:
+                tool_calls = parsed
+        return AIMessage(
+            content=payload.get("content", ""),
+            additional_kwargs={"tool_calls": tool_calls} if tool_calls else {},
+        )
+
+    @staticmethod
+    def _to_payload(message: BaseMessage) -> Dict[str, object]:
+        if isinstance(message, HumanMessage):
+            return {"role": "user", "content": message.content}
+        if isinstance(message, SystemMessage):
+            return {"role": "system", "content": message.content}
+        if isinstance(message, ToolMessage):
+            return {
+                "role": "tool",
+                "content": message.content,
+                "name": message.name,
+                "tool_call_id": message.tool_call_id,
+            }
+        if isinstance(message, AIMessage):
+            payload = {"role": "assistant", "content": message.content}
+            calls = message.additional_kwargs.get("tool_calls")
+            if calls:
+                payload["tool_calls"] = calls
+            return payload
+        return {"role": "user", "content": str(message.content)}
+
+    @staticmethod
+    def _try_parse_tool_call(content: str) -> List[Dict[str, object]]:
+        try:
+            data = json.loads(content)
+        except Exception:
+            return []
+        if isinstance(data, dict) and {"name", "arguments"} <= data.keys():
+            return [
+                {
+                    "id": data.get("id", "tool-0"),
+                    "type": "function",
+                    "function": {"name": data["name"], "arguments": json.dumps(data["arguments"])}
+                }
+            ]
+        if isinstance(data, list):
+            calls = []
+            for idx, item in enumerate(data):
+                if isinstance(item, dict) and {"name", "arguments"} <= item.keys():
+                    calls.append(
+                        {
+                            "id": item.get("id", f"tool-{idx}"),
+                            "type": "function",
+                            "function": {"name": item["name"], "arguments": json.dumps(item["arguments"])},
+                        }
+                    )
+            return calls
+        return []

--- a/assistant/rag.py
+++ b/assistant/rag.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence
+
+import numpy as np
+
+from .config import AssistantSettings
+
+LOGGER = logging.getLogger("videocatalog.assistant.rag")
+
+
+@dataclass(slots=True)
+class DocumentHit:
+    doc_id: str
+    score: float
+    text: str
+    metadata: Dict[str, object]
+
+
+class VectorIndex:
+    """Lazy semantic index backed by FAISS or hnswlib."""
+
+    def __init__(self, settings: AssistantSettings, db_path: Path, working_dir: Path) -> None:
+        self.settings = settings
+        self.db_path = db_path
+        self.working_dir = working_dir
+        self.index_dir = working_dir / "vectors"
+        self.index_dir.mkdir(parents=True, exist_ok=True)
+        self.index_path = self.index_dir / "catalog.index"
+        self.meta_path = self.index_dir / "catalog_meta.json"
+        self._lock = threading.Lock()
+        self._index = None
+        self._backend = settings.rag.index
+        self._dim = 384
+        self._meta: Dict[int, Dict[str, object]] = {}
+        self._embedder = None
+
+    # ------------------------------------------------------------------
+    def ensure_ready(self, force: bool = False) -> None:
+        if not self.settings.rag.enable:
+            return
+        with self._lock:
+            if not force and self._index is not None:
+                return
+            if not force and self.index_path.exists() and self.meta_path.exists():
+                self._load_index()
+                return
+            self._rebuild_index()
+
+    def refresh(self) -> None:
+        with self._lock:
+            self._rebuild_index()
+
+    # ------------------------------------------------------------------
+    def search(self, query: str, *, top_k: Optional[int] = None, min_score: Optional[float] = None) -> List[DocumentHit]:
+        if not self.settings.rag.enable:
+            return []
+        self.ensure_ready()
+        with self._lock:
+            if self._index is None:
+                return []
+            embedder = self._ensure_embedder()
+            vector = embedder.encode([query], convert_to_numpy=True, normalize_embeddings=True)[0]
+            k = top_k or self.settings.rag.top_k
+            labels, distances = self._knn_query(vector, k)
+            results: List[DocumentHit] = []
+            threshold = min_score if min_score is not None else self.settings.rag.min_score
+            for label, dist in zip(labels[0], distances[0]):
+                score = float(1 - dist)
+                if score < threshold:
+                    continue
+                meta = dict(self._meta.get(int(label), {}))
+                results.append(
+                    DocumentHit(
+                        doc_id=str(meta.get("doc_id", label)),
+                        score=score,
+                        text=str(meta.get("text", "")),
+                        metadata=meta,
+                    )
+                )
+            return results
+
+    # ------------------------------------------------------------------
+    def _load_index(self) -> None:
+        backend = self.settings.rag.index
+        if backend == "hnswlib":
+            try:
+                import hnswlib
+            except Exception as exc:
+                LOGGER.error("Failed to import hnswlib: %s", exc)
+                return
+            index = hnswlib.Index(space="cosine", dim=self._dim)
+            index.load_index(str(self.index_path))
+            with self.meta_path.open("r", encoding="utf-8") as fh:
+                meta_payload = json.load(fh)
+            self._meta = {int(k): v for k, v in meta_payload.get("entries", {}).items()}
+            self._index = index
+            LOGGER.info("Assistant RAG: loaded hnswlib index with %d entries", len(self._meta))
+            return
+        else:
+            try:
+                import faiss
+            except Exception as exc:
+                LOGGER.error("Failed to import faiss: %s", exc)
+                return
+            index = faiss.read_index(str(self.index_path))
+            with self.meta_path.open("r", encoding="utf-8") as fh:
+                meta_payload = json.load(fh)
+            self._meta = {int(k): v for k, v in meta_payload.get("entries", {}).items()}
+            self._index = index
+            LOGGER.info("Assistant RAG: loaded FAISS index with %d entries", len(self._meta))
+
+    def _rebuild_index(self) -> None:
+        backend = self.settings.rag.index
+        documents = list(self._collect_documents())
+        if not documents:
+            LOGGER.warning("Assistant RAG: no documents to index")
+            self._index = None
+            self._meta = {}
+            return
+        embedder = self._ensure_embedder()
+        texts = [doc.text for doc in documents]
+        vectors = embedder.encode(texts, convert_to_numpy=True, normalize_embeddings=True)
+        if backend == "hnswlib":
+            index = self._build_hnsw(vectors)
+        else:
+            index = self._build_faiss(vectors)
+        if index is None:
+            return
+        meta_entries = {
+            i: {"doc_id": doc.doc_id, "text": doc.text, **self._serialize_meta(doc.metadata)}
+            for i, doc in enumerate(documents)
+        }
+        with self.meta_path.open("w", encoding="utf-8") as fh:
+            json.dump({"entries": meta_entries}, fh, indent=2)
+        self._meta = meta_entries
+        if backend == "hnswlib":
+            index.save_index(str(self.index_path))
+        else:
+            import faiss
+
+            faiss.write_index(index, str(self.index_path))
+        self._index = index
+        LOGGER.info("Assistant RAG: rebuilt %s index with %d entries", backend, len(documents))
+
+    # ------------------------------------------------------------------
+    def _collect_documents(self) -> Iterable[DocumentHit]:
+        if not self.db_path.exists():
+            LOGGER.warning("Assistant RAG: catalog database missing at %s", self.db_path)
+            return []
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            tables = self._existing_tables(conn)
+            collectors = [
+                self._collect_docs_preview,
+                self._collect_textlite,
+                self._collect_music,
+                self._collect_inventory,
+            ]
+            for collector in collectors:
+                yield from collector(conn, tables)
+
+    def _collect_docs_preview(self, conn: sqlite3.Connection, tables: Sequence[str]) -> Iterable[DocumentHit]:
+        if "docs_preview" not in tables:
+            return []
+        rows = conn.execute(
+            "SELECT id, title, summary, keywords, path FROM docs_preview WHERE summary IS NOT NULL ORDER BY id LIMIT 5000"
+        )
+        for row in rows:
+            text = "\n".join([part for part in (row["title"], row["summary"], row["keywords"]) if part])
+            yield DocumentHit(
+                doc_id=f"doc:{row['id']}",
+                score=1.0,
+                text=text[:2000],
+                metadata={"type": "doc", "path": row["path"], "title": row["title"]},
+            )
+
+    def _collect_textlite(self, conn: sqlite3.Connection, tables: Sequence[str]) -> Iterable[DocumentHit]:
+        if "textlite_preview" not in tables:
+            return []
+        rows = conn.execute(
+            "SELECT id, path, head_excerpt, mid_excerpt, tail_excerpt FROM textlite_preview WHERE head_excerpt IS NOT NULL"
+        )
+        for row in rows:
+            text = "\n".join(
+                part
+                for part in (
+                    row["head_excerpt"],
+                    row["mid_excerpt"],
+                    row["tail_excerpt"],
+                )
+                if part
+            )
+            yield DocumentHit(
+                doc_id=f"text:{row['id']}",
+                score=1.0,
+                text=text[:2000],
+                metadata={"type": "text", "path": row["path"]},
+            )
+
+    def _collect_music(self, conn: sqlite3.Connection, tables: Sequence[str]) -> Iterable[DocumentHit]:
+        if "music_minimal" not in tables:
+            return []
+        rows = conn.execute(
+            "SELECT rowid AS id, title, artist, album, year, path FROM music_minimal ORDER BY rowid LIMIT 15000"
+        )
+        for row in rows:
+            text = " - ".join([part for part in (row["title"], row["artist"], row["album"]) if part])
+            text = f"{text} ({row['year']})" if row["year"] else text
+            yield DocumentHit(
+                doc_id=f"music:{row['id']}",
+                score=1.0,
+                text=text[:2000],
+                metadata={"type": "music", "path": row["path"]},
+            )
+
+    def _collect_inventory(self, conn: sqlite3.Connection, tables: Sequence[str]) -> Iterable[DocumentHit]:
+        if "inventory_view" in tables:
+            rows = conn.execute(
+                "SELECT inventory_id, title, year, type, drive_label FROM inventory_view ORDER BY inventory_id LIMIT 10000"
+            )
+            for row in rows:
+                parts = [row["title"] or "", str(row["year"] or ""), row["type"] or "", row["drive_label"] or ""]
+                text = " ".join(p for p in parts if p)
+                yield DocumentHit(
+                    doc_id=f"inventory:{row['inventory_id']}",
+                    score=1.0,
+                    text=text[:2000],
+                    metadata={"type": row["type"], "drive": row["drive_label"], "title": row["title"]},
+                )
+
+        return []
+
+    @staticmethod
+    def _existing_tables(conn: sqlite3.Connection) -> List[str]:
+        rows = conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        return [row[0] for row in rows]
+
+    def _ensure_embedder(self):
+        if self._embedder is None:
+            from sentence_transformers import SentenceTransformer
+
+            model_name = self.settings.rag.embed_model or "bge-small-en"
+            LOGGER.info("Assistant RAG: loading embeddings model %s", model_name)
+            self._embedder = SentenceTransformer(model_name)
+            self._dim = int(self._embedder.get_sentence_embedding_dimension())
+        return self._embedder
+
+    def _build_hnsw(self, vectors: np.ndarray):
+        try:
+            import hnswlib
+        except Exception as exc:
+            LOGGER.error("Assistant RAG: hnswlib unavailable (%s)", exc)
+            return None
+        num = len(vectors)
+        index = hnswlib.Index(space="cosine", dim=vectors.shape[1])
+        index.init_index(max_elements=num, ef_construction=200, M=48)
+        index.add_items(vectors, ids=np.arange(num))
+        index.set_ef(64)
+        return index
+
+    def _build_faiss(self, vectors: np.ndarray):
+        try:
+            import faiss
+        except Exception as exc:
+            LOGGER.error("Assistant RAG: faiss unavailable (%s)", exc)
+            return None
+        vectors = vectors.astype("float32")
+        num, dim = vectors.shape
+        index = faiss.IndexFlatIP(dim)
+        index.add(vectors)
+        return index
+
+    def _knn_query(self, vector: np.ndarray, k: int):
+        if self.settings.rag.index == "hnswlib":
+            labels, distances = self._index.knn_query(vector, k=k)
+            return labels, distances
+        import numpy as np
+
+        vector = np.array([vector], dtype="float32")
+        distances, labels = self._index.search(vector, k)
+        # Align signature with hnswlib (labels first, distances second)
+        return labels.astype(int), 1 - distances
+
+    @staticmethod
+    def _serialize_meta(meta: Dict[str, object]) -> Dict[str, object]:
+        normalized: Dict[str, object] = {}
+        for key, value in meta.items():
+            if isinstance(value, Path):
+                normalized[key] = str(value)
+            elif isinstance(value, (list, tuple)):
+                normalized[key] = [str(item) if isinstance(item, Path) else item for item in value]
+            else:
+                normalized[key] = value
+        return normalized

--- a/assistant/runtime.py
+++ b/assistant/runtime.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional
+
+import requests
+
+from .config import AssistantSettings
+
+LOGGER = logging.getLogger("videocatalog.assistant.runtime")
+
+OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "http://127.0.0.1:11434")
+LLAMA_CPP_HOST = "http://127.0.0.1:11435"
+
+
+@dataclass(slots=True)
+class RuntimeProbe:
+    name: str
+    available: bool
+    details: Dict[str, object]
+
+
+@dataclass(slots=True)
+class RuntimeHandle:
+    name: str
+    base_url: str
+    process: Optional[subprocess.Popen]
+    uses_gpu: bool
+
+
+class RuntimeManager:
+    """Detect and manage local LLM runtimes with graceful fallback."""
+
+    def __init__(self, settings: AssistantSettings, working_dir: Path) -> None:
+        self.settings = settings
+        self.working_dir = working_dir
+        self._lock = threading.Lock()
+        self._runtime: Optional[RuntimeHandle] = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def ensure_runtime(self) -> RuntimeHandle:
+        with self._lock:
+            if self._runtime is not None:
+                return self._runtime
+            runtime = (
+                self._probe_ollama()
+                if self.settings.runtime in ("auto", "ollama")
+                else None
+            )
+            if runtime is None and self.settings.runtime in ("auto", "llama_cpp"):
+                runtime = self._start_llama_cpp()
+            if runtime is None and self.settings.runtime in ("auto", "mlc"):
+                runtime = self._start_mlc_runtime()
+            if runtime is None:
+                raise RuntimeError("No local LLM runtime available. Install Ollama or enable llama.cpp.")
+            self._runtime = runtime
+            return runtime
+
+    def current_runtime(self) -> Optional[RuntimeHandle]:
+        with self._lock:
+            return self._runtime
+
+    # ------------------------------------------------------------------
+    # Runtime detection
+    # ------------------------------------------------------------------
+    def _probe_ollama(self) -> Optional[RuntimeHandle]:
+        try:
+            response = requests.get(f"{OLLAMA_HOST}/api/version", timeout=2)
+            response.raise_for_status()
+        except Exception as exc:
+            LOGGER.debug("Ollama probe failed: %s", exc)
+            return None
+        try:
+            system = requests.get(f"{OLLAMA_HOST}/api/ps", timeout=2).json()
+        except Exception:
+            system = {}
+        gpu_present = False
+        adapters = system.get("devices") if isinstance(system, dict) else None
+        if isinstance(adapters, list):
+            for adapter in adapters:
+                if isinstance(adapter, dict) and adapter.get("accelerator"):
+                    gpu_present = True
+                    break
+        LOGGER.info("Assistant runtime: using Ollama at %s (GPU=%s)", OLLAMA_HOST, gpu_present)
+        return RuntimeHandle(name="ollama", base_url=OLLAMA_HOST, process=None, uses_gpu=gpu_present)
+
+    def _start_llama_cpp(self) -> Optional[RuntimeHandle]:
+        if not self._check_llama_cpp_import():
+            return None
+        existing = self._probe_openai_server(LLAMA_CPP_HOST)
+        if existing:
+            LOGGER.info("Assistant runtime: using existing llama.cpp server at %s", LLAMA_CPP_HOST)
+            return RuntimeHandle(name="llama_cpp", base_url=LLAMA_CPP_HOST, process=None, uses_gpu=existing.uses_gpu)
+
+        LOGGER.info("Assistant runtime: launching llama.cpp server at %s", LLAMA_CPP_HOST)
+        env = os.environ.copy()
+        gpu_env = self._detect_cuda_env()
+        if gpu_env:
+            env.update(gpu_env)
+        command = [sys.executable, "-m", "llama_cpp.server", "--host", "127.0.0.1", "--port", "11435", "--chat_format", "functionary"]
+        process = subprocess.Popen(command, cwd=self.working_dir, env=env)
+        ready = self._wait_for_http(LLAMA_CPP_HOST, timeout=20)
+        if not ready:
+            LOGGER.error("llama.cpp server did not become ready")
+            process.terminate()
+            return None
+        uses_gpu = bool(gpu_env)
+        return RuntimeHandle(name="llama_cpp", base_url=LLAMA_CPP_HOST, process=process, uses_gpu=uses_gpu)
+
+    def _start_mlc_runtime(self) -> Optional[RuntimeHandle]:
+        # Placeholder for future DirectML/Vulkan runtime integration.
+        LOGGER.warning("MLC runtime not yet implemented; falling back to CPU-only llama.cpp")
+        if self.settings.runtime == "mlc":
+            return self._start_llama_cpp()
+        return None
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _wait_for_http(base_url: str, timeout: int = 10) -> bool:
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            try:
+                response = requests.get(base_url, timeout=1)
+                if response.status_code < 500:
+                    return True
+            except Exception:
+                time.sleep(0.4)
+        return False
+
+    @staticmethod
+    def _check_llama_cpp_import() -> bool:
+        try:
+            import llama_cpp  # noqa: F401
+        except Exception as exc:
+            LOGGER.warning("llama-cpp-python not available: %s", exc)
+            return False
+        return True
+
+    @staticmethod
+    def _probe_openai_server(base_url: str) -> Optional[RuntimeHandle]:
+        try:
+            response = requests.get(f"{base_url}/v1/models", timeout=2)
+            response.raise_for_status()
+        except Exception:
+            return None
+        try:
+            payload = response.json()
+        except Exception:
+            payload = {}
+        uses_gpu = False
+        data = payload.get("data")
+        if isinstance(data, list):
+            for item in data:
+                if isinstance(item, dict) and "gpu" in json.dumps(item).lower():
+                    uses_gpu = True
+                    break
+        return RuntimeHandle(name="llama_cpp", base_url=base_url, process=None, uses_gpu=uses_gpu)
+
+    @staticmethod
+    def _detect_cuda_env() -> Dict[str, str]:
+        """Attempt to detect CUDA support and surface best provider env vars."""
+
+        try:
+            from gpu.capabilities import probe_gpu  # lazy import to avoid cycles
+        except Exception:
+            return {}
+        caps = probe_gpu()
+        if caps.get("cuda_available"):
+            return {"LLAMA_CPP_USE_CUBLAS": "1"}
+        if caps.get("dml_available"):
+            return {"LLAMA_CPP_USE_DIRECTML": "1"}
+        return {}
+
+    def shutdown(self) -> None:
+        with self._lock:
+            runtime = self._runtime
+            self._runtime = None
+        if runtime and runtime.process:
+            runtime.process.terminate()
+            try:
+                runtime.process.wait(timeout=5)
+            except Exception:
+                runtime.process.kill()

--- a/assistant/service.py
+++ b/assistant/service.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import threading
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage, ToolMessage
+
+from .config import AssistantSettings
+from .controller import AssistantController
+from .llm_client import LLMClient
+from .rag import VectorIndex
+from .runtime import RuntimeManager
+from .tools import AssistantTooling
+
+LOGGER = logging.getLogger("videocatalog.assistant.service")
+
+SYSTEM_PROMPT = """
+You are a VideoCatalog assistant integrated in a Windows desktop app. You MUST obey these policies:
+- Never rename, move, delete or modify media files. Media folders are read-only.
+- Use provided tools to inspect the SQLite catalog database or semantic index when necessary.
+- Prefer concise answers with numbered steps. Mention sources (table names, titles) when appropriate.
+- If unsure or lacking permission, explain the limitation instead of guessing.
+""".strip()
+
+
+@dataclass(slots=True)
+class AssistantStatus:
+    runtime: str
+    model: str
+    uses_gpu: bool
+    rag_enabled: bool
+    tool_budget: int
+    remaining_budget: int
+
+
+class AssistantService:
+    def __init__(self, settings_payload: Dict[str, object], working_dir: Path, db_path: Path) -> None:
+        self.settings = AssistantSettings.from_settings(settings_payload)
+        self.working_dir = working_dir
+        self.db_path = db_path
+        self.vector_index = VectorIndex(self.settings, db_path, working_dir)
+        self.runtime_manager = RuntimeManager(self.settings, working_dir)
+        tmdb_key = self._resolve_tmdb_key(settings_payload)
+        self.tooling = AssistantTooling(self.settings, db_path, working_dir, self.vector_index, tmdb_api_key=tmdb_key)
+        self.controller: Optional[AssistantController] = None
+        self.history: List[BaseMessage] = []
+        self.session_id: Optional[str] = None
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    def ensure_ready(self) -> AssistantStatus:
+        if not self.settings.enable:
+            raise RuntimeError("Assistant is disabled in settings.")
+        runtime = self.runtime_manager.ensure_runtime()
+        if self.settings.rag.refresh_on_start:
+            self.vector_index.ensure_ready(force=True)
+        else:
+            self.vector_index.ensure_ready()
+        self.tooling.reset_budget(self.settings.tool_budget)
+        client = LLMClient(runtime, self.settings.model, temperature=self.settings.temperature, ctx=self.settings.ctx)
+        self.controller = AssistantController(client, self.tooling, system_prompt=SYSTEM_PROMPT)
+        self._ensure_memory_tables()
+        return AssistantStatus(
+            runtime=runtime.name,
+            model=self.settings.model,
+            uses_gpu=runtime.uses_gpu,
+            rag_enabled=self.settings.rag.enable,
+            tool_budget=self.settings.tool_budget,
+            remaining_budget=self.settings.tool_budget,
+        )
+
+    def start_session(self, scope: str = "global") -> AssistantStatus:
+        with self._lock:
+            status = self.ensure_ready()
+            self.session_id = self._ensure_session(scope)
+            self.history = self._load_recent_history(limit=12)
+            return status
+
+    def ask(self, text: str, *, use_rag: bool = True) -> Dict[str, object]:
+        with self._lock:
+            if self.controller is None:
+                status = self.start_session()
+            else:
+                status = self.status()
+            rag_snippets = []
+            if use_rag and self.settings.rag.enable:
+                hits = self.vector_index.search(text)
+                for hit in hits[: self.settings.rag.top_k]:
+                    rag_snippets.append(f"{hit.metadata.get('title') or hit.metadata.get('path')}: {hit.text[:200]}")
+            prompt = text
+            if rag_snippets:
+                prompt = f"{text}\n\nContext from catalog:\n" + "\n".join(rag_snippets)
+            human = HumanMessage(content=prompt)
+            messages: List[BaseMessage] = [SystemMessage(content=SYSTEM_PROMPT), *self.history, human]
+            if self.controller is None:
+                raise RuntimeError("Assistant controller not ready")
+            final_state = self.controller.run(messages)
+            history = final_state["messages"]
+            responses = [msg for msg in history if isinstance(msg, AIMessage)]
+            answer = responses[-1] if responses else AIMessage(content="No answer produced.")
+            self.history = [msg for msg in history if isinstance(msg, (HumanMessage, AIMessage))][-8:]
+            self._persist_exchange(text, answer.content)
+            tool_messages = [msg for msg in history if isinstance(msg, ToolMessage)]
+            tool_log = []
+            for tool_msg in tool_messages[-4:]:
+                try:
+                    payload = json.loads(tool_msg.content)
+                except Exception:
+                    payload = {"raw": tool_msg.content}
+                tool_log.append({"tool": tool_msg.name, "payload": payload})
+            return {
+                "answer": answer.content,
+                "tool_log": tool_log,
+                "status": self.status(),
+            }
+
+    def refresh_index(self) -> None:
+        self.vector_index.refresh()
+
+    def status(self) -> AssistantStatus:
+        runtime = self.runtime_manager.current_runtime()
+        uses_gpu = runtime.uses_gpu if runtime else False
+        remaining = max(0, self.settings.tool_budget - self.tooling.calls)
+        return AssistantStatus(
+            runtime=runtime.name if runtime else "unknown",
+            model=self.settings.model,
+            uses_gpu=uses_gpu,
+            rag_enabled=self.settings.rag.enable,
+            tool_budget=self.settings.tool_budget,
+            remaining_budget=remaining,
+        )
+
+    def shutdown(self) -> None:
+        self.runtime_manager.shutdown()
+
+    # ------------------------------------------------------------------
+    def _ensure_session(self, scope: str) -> str:
+        session_id = str(uuid.uuid4())
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS assistant_sessions (
+                    id TEXT PRIMARY KEY,
+                    scope TEXT NOT NULL,
+                    created_utc TEXT NOT NULL DEFAULT (datetime('now'))
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS assistant_messages (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    session_id TEXT NOT NULL,
+                    role TEXT NOT NULL,
+                    content TEXT NOT NULL,
+                    created_utc TEXT NOT NULL DEFAULT (datetime('now')),
+                    FOREIGN KEY(session_id) REFERENCES assistant_sessions(id)
+                )
+                """
+            )
+            conn.execute("INSERT INTO assistant_sessions(id, scope) VALUES(?, ?)", (session_id, scope))
+            conn.commit()
+        return session_id
+
+    def _persist_exchange(self, question: str, answer: str) -> None:
+        if not self.session_id:
+            return
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "INSERT INTO assistant_messages(session_id, role, content) VALUES(?,?,?)",
+                (self.session_id, "user", question),
+            )
+            conn.execute(
+                "INSERT INTO assistant_messages(session_id, role, content) VALUES(?,?,?)",
+                (self.session_id, "assistant", answer),
+            )
+            conn.commit()
+
+    def _load_recent_history(self, limit: int = 12) -> List[BaseMessage]:
+        if not self.session_id:
+            return []
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                "SELECT role, content FROM assistant_messages WHERE session_id=? ORDER BY id DESC LIMIT ?",
+                (self.session_id, limit),
+            ).fetchall()
+        messages: List[BaseMessage] = []
+        for row in reversed(rows):
+            if row["role"] == "assistant":
+                messages.append(AIMessage(content=row["content"]))
+            else:
+                messages.append(HumanMessage(content=row["content"]))
+        return messages
+
+    def _ensure_memory_tables(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS assistant_sessions (
+                    id TEXT PRIMARY KEY,
+                    scope TEXT NOT NULL,
+                    created_utc TEXT NOT NULL DEFAULT (datetime('now'))
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS assistant_messages (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    session_id TEXT NOT NULL,
+                    role TEXT NOT NULL,
+                    content TEXT NOT NULL,
+                    created_utc TEXT NOT NULL DEFAULT (datetime('now')),
+                    FOREIGN KEY(session_id) REFERENCES assistant_sessions(id)
+                )
+                """
+            )
+            conn.commit()
+
+    @staticmethod
+    def _resolve_tmdb_key(settings_payload: Dict[str, object]) -> Optional[str]:
+        structure = settings_payload.get("structure") if isinstance(settings_payload.get("structure"), dict) else {}
+        tmdb = structure.get("tmdb") if isinstance(structure.get("tmdb"), dict) else {}
+        key = tmdb.get("api_key")
+        if isinstance(key, str) and key.strip():
+            return key.strip()
+        return None

--- a/assistant/tools.py
+++ b/assistant/tools.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+import csv
+import logging
+import re
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from .apiguard import ApiGuard
+from .config import AssistantSettings
+from .rag import VectorIndex
+
+LOGGER = logging.getLogger("videocatalog.assistant.tools")
+
+READ_ONLY_SQL = re.compile(r"^\s*select\b", re.IGNORECASE)
+
+
+class ToolBudgetExceeded(RuntimeError):
+    pass
+
+
+@dataclass(slots=True)
+class ToolDefinition:
+    name: str
+    description: str
+    parameters: Dict[str, Any]
+
+
+class AssistantTooling:
+    def __init__(
+        self,
+        settings: AssistantSettings,
+        db_path: Path,
+        working_dir: Path,
+        vector_index: VectorIndex,
+        *,
+        tmdb_api_key: Optional[str] = None,
+    ) -> None:
+        self.settings = settings
+        self.db_path = db_path
+        self.working_dir = working_dir
+        self.vector_index = vector_index
+        self.tmdb_api_key = tmdb_api_key
+        self.budget = settings.tool_budget
+        self.calls = 0
+        self.api_guard = ApiGuard(working_dir, tmdb_api_key)
+
+    # ------------------------------------------------------------------
+    def reset_budget(self, budget: Optional[int] = None) -> None:
+        self.calls = 0
+        if budget is not None:
+            self.budget = budget
+
+    def definitions(self) -> List[ToolDefinition]:
+        return [
+            ToolDefinition(
+                name="db_query_sql",
+                description="Run a read-only SELECT query against catalog views.",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "sql": {"type": "string", "description": "SELECT query using only catalog views."},
+                        "params": {
+                            "type": "array",
+                            "items": {"type": ["string", "number", "null"]},
+                            "default": [],
+                        },
+                        "limit": {"type": "integer", "minimum": 1, "maximum": 500, "default": 100},
+                    },
+                    "required": ["sql"],
+                },
+            ),
+            ToolDefinition(
+                name="db_search_semantic",
+                description="Search the semantic vector index for catalog items.",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string"},
+                        "top_k": {"type": "integer", "minimum": 1, "maximum": 20, "default": 8},
+                        "min_score": {"type": "number", "minimum": 0, "maximum": 1},
+                        "filters": {
+                            "type": "object",
+                            "properties": {
+                                "type": {"type": "string"},
+                                "drive_label": {"type": "string"},
+                            },
+                        },
+                    },
+                    "required": ["query"],
+                },
+            ),
+            ToolDefinition(
+                name="get_paths_for_title",
+                description="Return candidate file system paths for a given title and optional year.",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "title": {"type": "string"},
+                        "year": {"type": ["integer", "null"]},
+                        "limit": {"type": "integer", "minimum": 1, "maximum": 50, "default": 12},
+                    },
+                    "required": ["title"],
+                },
+            ),
+            ToolDefinition(
+                name="get_low_confidence_items",
+                description="Fetch items pending review due to low confidence signals.",
+                parameters={"type": "object", "properties": {}, "required": []},
+            ),
+            ToolDefinition(
+                name="create_task",
+                description="Create a follow-up task for manual review (stored in DB).",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "title": {"type": "string"},
+                        "details": {"type": "string"},
+                        "priority": {"type": "string", "enum": ["low", "normal", "high"], "default": "normal"},
+                    },
+                    "required": ["title"],
+                },
+            ),
+            ToolDefinition(
+                name="export_csv",
+                description="Create a CSV export within the working_dir/exports folder.",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "sql": {"type": "string"},
+                        "filename": {"type": "string"},
+                        "dry_run": {"type": "boolean", "default": True},
+                        "limit": {"type": "integer", "minimum": 1, "maximum": 2000, "default": 500},
+                    },
+                    "required": ["sql", "filename"],
+                },
+            ),
+            ToolDefinition(
+                name="api_tmdb_lookup_cached",
+                description="Query TMDB through the local API guard cache.",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "endpoint": {"type": "string"},
+                        "params": {"type": "object"},
+                    },
+                    "required": ["endpoint"],
+                },
+            ),
+            ToolDefinition(
+                name="help_open_folder",
+                description="Return a shell-open plan for a path without modifying files.",
+                parameters={
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"],
+                },
+            ),
+        ]
+
+    # ------------------------------------------------------------------
+    def execute(self, name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        if not self.settings.tools_enabled:
+            raise RuntimeError("Tool execution disabled for this session.")
+        if self.calls >= self.budget:
+            raise ToolBudgetExceeded("Tool budget exhausted for this session.")
+        handler = getattr(self, f"_tool_{name}", None)
+        if handler is None:
+            raise RuntimeError(f"Unknown tool: {name}")
+        self.calls += 1
+        resolved_args = dict(arguments or {})
+        result = handler(**resolved_args)
+        LOGGER.debug("Tool %s executed (call %d/%d)", name, self.calls, self.budget)
+        return {"name": name, "arguments": resolved_args, "result": result}
+
+    # ------------------------------------------------------------------
+    def _tool_db_query_sql(self, sql: str, params: Optional[List[Any]] = None, limit: int = 100) -> Dict[str, Any]:
+        self._ensure_db()
+        if not READ_ONLY_SQL.match(sql):
+            raise RuntimeError("Only SELECT statements are allowed.")
+        params = params or []
+        limit = max(1, min(500, int(limit)))
+        sql_wrapped = f"SELECT * FROM ({sql}) LIMIT {limit}"
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(sql_wrapped, params).fetchall()
+        return {
+            "rows": [dict(row) for row in rows],
+            "count": len(rows),
+        }
+
+    def _tool_db_search_semantic(
+        self,
+        query: str,
+        top_k: Optional[int] = None,
+        min_score: Optional[float] = None,
+        filters: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]:
+        hits = self.vector_index.search(query, top_k=top_k, min_score=min_score)
+        filtered = []
+        filters = filters or {}
+        for hit in hits:
+            meta = hit.metadata
+            if filters.get("type") and meta.get("type") != filters.get("type"):
+                continue
+            if filters.get("drive_label") and meta.get("drive") != filters.get("drive_label"):
+                continue
+            filtered.append({"doc_id": hit.doc_id, "score": hit.score, "metadata": meta})
+        return {"results": filtered}
+
+    def _tool_get_paths_for_title(self, title: str, year: Optional[int] = None, limit: int = 12) -> Dict[str, Any]:
+        self._ensure_db()
+        limit = max(1, min(50, limit))
+        like = f"%{title.strip()}%"
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            tables = self._existing_tables(conn)
+            results: List[Dict[str, Any]] = []
+            if "inventory_view" in tables:
+                query = "SELECT title, year, type, drive_label, path FROM inventory_view WHERE title LIKE ?"
+                params: List[Any] = [like]
+                if year:
+                    query += " AND year=?"
+                    params.append(int(year))
+                query += " LIMIT ?"
+                params.append(limit)
+                for row in conn.execute(query, params):
+                    results.append(dict(row))
+            elif "files" in tables:
+                query = "SELECT path FROM files WHERE path LIKE ? LIMIT ?"
+                for row in conn.execute(query, [like, limit]):
+                    results.append({"path": row["path"]})
+        return {"paths": results}
+
+    def _tool_get_low_confidence_items(self) -> Dict[str, Any]:
+        self._ensure_db()
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            tables = self._existing_tables(conn)
+            payload: Dict[str, Any] = {}
+            if "structure_review_queue" in tables:
+                rows = conn.execute(
+                    "SELECT title, year, drive_label, reason, created_utc FROM structure_review_queue ORDER BY created_utc DESC LIMIT 25"
+                )
+                payload["structure"] = [dict(row) for row in rows]
+            if "quality_alerts" in tables:
+                rows = conn.execute(
+                    "SELECT path, issue_code, severity, created_utc FROM quality_alerts ORDER BY created_utc DESC LIMIT 25"
+                )
+                payload["quality"] = [dict(row) for row in rows]
+            return payload
+
+    def _tool_create_task(self, title: str, details: Optional[str] = None, priority: str = "normal") -> Dict[str, Any]:
+        self._ensure_db()
+        priority = priority.lower()
+        if priority not in {"low", "normal", "high"}:
+            priority = "normal"
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS tasks (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    title TEXT NOT NULL,
+                    details TEXT,
+                    priority TEXT NOT NULL,
+                    created_utc TEXT NOT NULL DEFAULT (datetime('now')),
+                    status TEXT NOT NULL DEFAULT 'open'
+                )
+                """
+            )
+            conn.execute(
+                "INSERT INTO tasks(title, details, priority) VALUES(?,?,?)",
+                (title, details, priority),
+            )
+            conn.commit()
+        return {"status": "created", "title": title, "priority": priority}
+
+    def _tool_export_csv(self, sql: str, filename: str, dry_run: bool = True, limit: int = 500) -> Dict[str, Any]:
+        self._ensure_db()
+        if not READ_ONLY_SQL.match(sql):
+            raise RuntimeError("Only SELECT statements are allowed for exports.")
+        limit = max(1, min(2000, limit))
+        sql_wrapped = f"SELECT * FROM ({sql}) LIMIT {limit}"
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(sql_wrapped).fetchall()
+        rows_payload = [dict(row) for row in rows]
+        if dry_run:
+            return {"rows": rows_payload[:10], "row_count": len(rows_payload), "dry_run": True}
+        exports_dir = self.working_dir / "exports"
+        exports_dir.mkdir(parents=True, exist_ok=True)
+        safe_name = filename.replace("..", "_")
+        target = exports_dir / safe_name
+        with target.open("w", encoding="utf-8", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=list(rows_payload[0].keys()) if rows_payload else [])
+            if rows_payload:
+                writer.writeheader()
+                writer.writerows(rows_payload)
+        return {"path": str(target), "row_count": len(rows_payload), "dry_run": False}
+
+    def _tool_api_tmdb_lookup_cached(self, endpoint: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        payload = self.api_guard.tmdb_lookup(endpoint, params=params or {})
+        return {"endpoint": endpoint, "payload": payload}
+
+    def _tool_help_open_folder(self, path: str) -> Dict[str, Any]:
+        resolved = str(Path(path))
+        return {"action": "open", "path": resolved}
+
+    # ------------------------------------------------------------------
+    def _ensure_db(self) -> None:
+        if not self.db_path.exists():
+            raise RuntimeError(f"Catalog database missing at {self.db_path}")
+
+    @staticmethod
+    def _existing_tables(conn: sqlite3.Connection) -> Iterable[str]:
+        rows = conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        return [row[0] for row in rows]

--- a/core/settings.py
+++ b/core/settings.py
@@ -123,6 +123,23 @@ DEFAULT_SETTINGS: Dict[str, Any] = {
         "default_limit": 100,
         "max_page_size": 500,
     },
+    "assistant": {
+        "enable": False,
+        "runtime": "auto",
+        "model": "qwen2.5:7b-instruct",
+        "ctx": 8192,
+        "temperature": 0.3,
+        "tools_enabled": True,
+        "tool_budget": 20,
+        "rag": {
+            "enable": True,
+            "top_k": 8,
+            "min_score": 0.25,
+            "embed_model": "bge-small-en",
+            "index": "faiss",
+            "refresh_on_start": False,
+        },
+    },
     "structure": {
         "enable": True,
         "weights": {

--- a/core/settings_schema.py
+++ b/core/settings_schema.py
@@ -27,6 +27,7 @@ _ALLOWED_STRUCTURE: Dict[str, Any] = {
     "delta_scan": "*",
     "gpu": "*",
     "api": "*",
+    "assistant": "*",
     "structure": "*",
     "docpreview": "*",
     "textlite": "*",

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,9 @@ pytesseract
 transformers
 yake
 langdetect
+langgraph
+langchain-core
+langchain-community
+sentence-transformers
+hnswlib
+llama-cpp-python

--- a/settings.json
+++ b/settings.json
@@ -68,6 +68,23 @@
     "default_limit": 100,
     "max_page_size": 500
   },
+  "assistant": {
+    "enable": false,
+    "runtime": "auto",
+    "model": "qwen2.5:7b-instruct",
+    "ctx": 8192,
+    "temperature": 0.3,
+    "tools_enabled": true,
+    "tool_budget": 20,
+    "rag": {
+      "enable": true,
+      "top_k": 8,
+      "min_score": 0.25,
+      "embed_model": "bge-small-en",
+      "index": "faiss",
+      "refresh_on_start": false
+    }
+  },
   "structure": {
     "enable": true,
     "weights": {


### PR DESCRIPTION
## Summary
- add a new assistant package that manages runtime detection (Ollama or llama.cpp), embeddings, RAG indexing, and tool execution against the catalog database
- extend default settings, schema, and requirements with assistant configuration, LangGraph, and vector search dependencies
- integrate an "Assistant" tab into the GUI with chat controls, runtime status, tool logs, and persistable settings

## Testing
- python -m compileall assistant
- python -m compileall DiskScannerGUI.py

------
https://chatgpt.com/codex/tasks/task_e_68ea499617208327ab8c5bbd7abad984