### PR TITLE
Add diagnostics framework with GPU gating and Debug tab

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -277,6 +277,24 @@ DEFAULT_SETTINGS: Dict[str, Any] = {
         "sheet_quality": 80,
         "sheet_optimize": True,
     },
+    "diagnostics": {
+        "enable": True,
+        "gpu_hard_requirement": True,
+        "smoke_timeouts_s": {
+            "movies": 10,
+            "tv": 10,
+            "apiguard": 10,
+            "visual": 10,
+            "docs": 10,
+            "assistant": 10,
+        },
+        "sample_sizes": {
+            "movies": 5,
+            "tv": 5,
+            "docs": 3,
+        },
+        "logs_keep_days": 14,
+    },
 }
 
 

--- a/core/settings_schema.py
+++ b/core/settings_schema.py
@@ -33,6 +33,7 @@ _ALLOWED_STRUCTURE: Dict[str, Any] = {
     "docpreview": "*",
     "textlite": "*",
     "textverify": "*",
+    "diagnostics": "*",
     "working_dir": None,
     "catalog_db": None,
     "version": None,

--- a/diagnostics/__init__.py
+++ b/diagnostics/__init__.py
@@ -1,0 +1,20 @@
+"""Diagnostics package for VideoCatalog."""
+
+from .preflight import run_preflight
+from .smoke import run_smoke_tests
+from .report import build_report_snapshot, export_report_bundle
+from .logs import log_event, query_logs, purge_old_logs, latest_preflight_path, latest_smoke_path
+from .tools import DiagnosticsTools
+
+__all__ = [
+    "run_preflight",
+    "run_smoke_tests",
+    "build_report_snapshot",
+    "export_report_bundle",
+    "log_event",
+    "query_logs",
+    "purge_old_logs",
+    "latest_preflight_path",
+    "latest_smoke_path",
+    "DiagnosticsTools",
+]

--- a/diagnostics/logs.py
+++ b/diagnostics/logs.py
@@ -1,0 +1,194 @@
+"""Structured diagnostics logging helpers."""
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any, Dict, Iterable, Iterator, Optional
+
+from core.paths import get_logs_dir, resolve_working_dir
+
+LOG_FILENAME = "diagnostics.log.jsonl"
+PREFLIGHT_SNAPSHOT = "diagnostics_preflight.json"
+SMOKE_SNAPSHOT = "diagnostics_smoke.json"
+
+EVENT_RANGES = {
+    "preflight": (1000, 1999),
+    "smoke": (2000, 2999),
+    "apiguard": (3000, 3999),
+    "assistant": (4000, 4999),
+}
+
+
+class DiagnosticsLogError(Exception):
+    """Raised when diagnostics logs cannot be processed."""
+
+
+def _ensure_logs_dir(working_dir: Optional[Path] = None) -> Path:
+    base = working_dir or resolve_working_dir()
+    logs_dir = get_logs_dir(base)
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    return logs_dir
+
+
+def _log_path(working_dir: Optional[Path] = None) -> Path:
+    return _ensure_logs_dir(working_dir) / LOG_FILENAME
+
+
+def _snapshot_path(filename: str, working_dir: Optional[Path] = None) -> Path:
+    return _ensure_logs_dir(working_dir) / filename
+
+
+def latest_preflight_path(working_dir: Optional[Path] = None) -> Path:
+    return _snapshot_path(PREFLIGHT_SNAPSHOT, working_dir)
+
+
+def latest_smoke_path(working_dir: Optional[Path] = None) -> Path:
+    return _snapshot_path(SMOKE_SNAPSHOT, working_dir)
+
+
+def log_event(
+    *,
+    event_id: int,
+    level: str,
+    module: str,
+    op: str,
+    working_dir: Optional[Path] = None,
+    duration_ms: Optional[float] = None,
+    ok: Optional[bool] = None,
+    err_code: Optional[str] = None,
+    hint: Optional[str] = None,
+    path: Optional[str] = None,
+    extra: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Append a structured diagnostics log entry."""
+
+    record = {
+        "ts": time.time(),
+        "level": (level or "INFO").upper(),
+        "event_id": int(event_id),
+        "module": module,
+        "op": op,
+    }
+    if duration_ms is not None:
+        record["duration_ms"] = float(duration_ms)
+    if ok is not None:
+        record["ok"] = bool(ok)
+    if err_code:
+        record["err_code"] = str(err_code)
+    if hint:
+        record["hint"] = str(hint)
+    if path:
+        record["path"] = str(path)
+    if extra:
+        record.update(extra)
+    log_path = _log_path(working_dir)
+    with open(log_path, "a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, ensure_ascii=False) + os.linesep)
+
+
+def persist_snapshot(name: str, payload: Dict[str, Any], *, working_dir: Optional[Path] = None) -> Path:
+    """Persist the latest preflight/smoke snapshot for reuse."""
+
+    filename = PREFLIGHT_SNAPSHOT if name == "preflight" else SMOKE_SNAPSHOT
+    path = _snapshot_path(filename, working_dir)
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, indent=2)
+    return path
+
+
+def load_snapshot(name: str, *, working_dir: Optional[Path] = None) -> Optional[Dict[str, Any]]:
+    filename = PREFLIGHT_SNAPSHOT if name == "preflight" else SMOKE_SNAPSHOT
+    path = _snapshot_path(filename, working_dir)
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except FileNotFoundError:
+        return None
+    except json.JSONDecodeError as exc:
+        raise DiagnosticsLogError(f"Snapshot {filename} corrupted: {exc}") from exc
+    if isinstance(payload, dict):
+        return payload
+    return None
+
+
+def _iter_logs(path: Path) -> Iterator[Dict[str, Any]]:
+    if not path.exists():
+        return iter(())
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    yield json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+    except FileNotFoundError:
+        return iter(())
+
+
+def query_logs(
+    *,
+    query: Optional[Dict[str, Any]] = None,
+    limit: int = 200,
+    working_dir: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Return the latest log lines filtered by event_id/module/level."""
+
+    log_path = _log_path(working_dir)
+    filters = dict(query or {})
+    level = filters.get("level")
+    module_filter = filters.get("module")
+    event_id_filter = filters.get("event_id")
+    matched: list[Dict[str, Any]] = []
+    for record in _iter_logs(log_path):
+        if level and str(record.get("level", "")).upper() != str(level).upper():
+            continue
+        if module_filter and module_filter not in str(record.get("module", "")):
+            continue
+        if event_id_filter is not None:
+            try:
+                event_id_value = int(event_id_filter)
+            except (TypeError, ValueError):
+                event_id_value = None
+            if event_id_value is not None and int(record.get("event_id", -1)) != event_id_value:
+                continue
+        matched.append(record)
+    matched = matched[-int(limit) :]
+    return {"rows": matched, "count": len(matched)}
+
+
+def purge_old_logs(*, keep_days: int, working_dir: Optional[Path] = None) -> None:
+    """Trim diagnostics logs older than *keep_days*."""
+
+    if keep_days <= 0:
+        return
+    threshold = time.time() - keep_days * 86400
+    log_path = _log_path(working_dir)
+    if not log_path.exists():
+        return
+    try:
+        with open(log_path, "r", encoding="utf-8") as handle:
+            rows = [json.loads(line) for line in handle if line.strip()]
+    except (FileNotFoundError, json.JSONDecodeError):
+        return
+    filtered = [row for row in rows if float(row.get("ts", 0)) >= threshold]
+    with open(log_path, "w", encoding="utf-8") as handle:
+        for row in filtered:
+            handle.write(json.dumps(row, ensure_ascii=False) + os.linesep)
+
+
+__all__ = [
+    "EVENT_RANGES",
+    "DiagnosticsLogError",
+    "log_event",
+    "query_logs",
+    "purge_old_logs",
+    "persist_snapshot",
+    "load_snapshot",
+    "latest_preflight_path",
+    "latest_smoke_path",
+]

--- a/diagnostics/preflight.py
+++ b/diagnostics/preflight.py
@@ -1,0 +1,508 @@
+"""Preflight diagnostics for VideoCatalog."""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from core import db as core_db
+from core.paths import get_catalog_db_path, get_logs_dir, resolve_working_dir
+from core.settings import load_settings
+from core.settings_schema import SETTINGS_VALIDATOR
+from gpu.capabilities import probe_gpu
+
+from .logs import EVENT_RANGES, log_event, persist_snapshot, purge_old_logs
+
+MIN_VRAM_GB = 8.0
+
+
+@dataclass(slots=True)
+class CheckResult:
+    name: str
+    ok: bool
+    severity: str
+    message: str
+    hint: Optional[str] = None
+    data: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class PreflightResult:
+    ts: float
+    gpu_ready: bool
+    sections: Dict[str, Dict[str, Any]]
+    checks: List[CheckResult]
+
+    def summary(self) -> Dict[str, int]:
+        summary = {"MAJOR": 0, "MINOR": 0, "INFO": 0}
+        for check in self.checks:
+            summary[check.severity.upper()] = summary.get(check.severity.upper(), 0) + (0 if check.ok else 1)
+        return summary
+
+
+def _version_of(cmd: List[str]) -> Optional[str]:
+    try:
+        completed = subprocess.run(cmd, capture_output=True, text=True, timeout=5, check=False)
+    except (FileNotFoundError, PermissionError, subprocess.SubprocessError):
+        return None
+    output = completed.stdout or completed.stderr or ""
+    for line in output.splitlines():
+        line = line.strip()
+        if line:
+            return line
+    return None
+
+
+def _check_gpu(*, settings: Dict[str, Any], working_dir: Path) -> Tuple[bool, Dict[str, Any], CheckResult]:
+    start = time.perf_counter()
+    try:
+        caps = probe_gpu(refresh=True)
+    except Exception as exc:  # pragma: no cover - defensive
+        duration = (time.perf_counter() - start) * 1000
+        log_event(
+            event_id=EVENT_RANGES["preflight"][0],
+            level="ERROR",
+            module="diagnostics.preflight",
+            op="gpu_probe",
+            duration_ms=duration,
+            ok=False,
+            err_code="GPU_PROBE_FAIL",
+            hint="Install NVIDIA drivers and retry",
+            extra={"error": str(exc)},
+            working_dir=working_dir,
+        )
+        data = {"present": False, "name": None, "vram_gb": 0.0, "cuda_ok": False, "driver_ver": None, "free_vram_gb": 0.0}
+        check = CheckResult(
+            name="gpu",
+            ok=False,
+            severity="MAJOR",
+            message="GPU probe failed",
+            hint="Install NVIDIA drivers and CUDA runtime",
+            data=data,
+        )
+        return False, data, check
+
+    total_bytes = caps.get("nv_vram_bytes") or 0
+    free_bytes = caps.get("nv_free_vram_bytes") or 0
+    vram_gb = float(total_bytes) / (1024 ** 3) if total_bytes else 0.0
+    free_gb = float(free_bytes) / (1024 ** 3) if free_bytes else 0.0
+    present = bool(caps.get("has_nvidia"))
+    driver = caps.get("nv_driver_version")
+    cuda_runtime = bool(caps.get("cuda_available"))
+    cuda_ok = bool(caps.get("onnx_cuda_ok"))
+    ready = present and vram_gb >= MIN_VRAM_GB and cuda_runtime and cuda_ok
+    severity = "INFO" if ready else "MAJOR"
+    hint = None
+    message = "GPU ready"
+    if not present:
+        message = "GPU not ready: NVIDIA adapter missing"
+        hint = "Install a supported NVIDIA GPU (>=8GB VRAM)."
+    elif vram_gb < MIN_VRAM_GB:
+        message = f"GPU not ready: only {vram_gb:.1f} GiB VRAM detected"
+        hint = "Upgrade GPU or free VRAM; VideoCatalog requires >=8GB."
+    elif not cuda_runtime:
+        message = "GPU not ready: CUDA runtime unavailable"
+        hint = "Install CUDA runtime/driver package."
+    elif not cuda_ok:
+        message = "GPU not ready: ONNX CUDA provider failed"
+        hint = "Install onnxruntime-gpu dependencies (CUDA, cuDNN)."
+
+    details = {
+        "present": present,
+        "name": caps.get("nv_name"),
+        "vram_gb": round(vram_gb, 2),
+        "free_vram_gb": round(free_gb, 2),
+        "cuda_ok": cuda_ok,
+        "cuda_runtime": cuda_runtime,
+        "driver_ver": driver,
+        "directml_ok": bool(caps.get("onnx_directml_ok")),
+    }
+    duration = (time.perf_counter() - start) * 1000
+    log_event(
+        event_id=EVENT_RANGES["preflight"][0],
+        level="INFO" if ready else "ERROR",
+        module="diagnostics.preflight",
+        op="gpu",
+        duration_ms=duration,
+        ok=ready,
+        hint=hint,
+        extra=details,
+        working_dir=working_dir,
+    )
+    check = CheckResult(name="gpu", ok=ready, severity=severity, message=message, hint=hint, data=details)
+    return ready, details, check
+
+
+def _check_tools(*, working_dir: Path) -> Tuple[Dict[str, Any], List[CheckResult]]:
+    tools = {
+        "ffprobe": {"cmd": ["ffprobe", "-version"]},
+        "tesseract": {"cmd": ["tesseract", "--version"]},
+    }
+    statuses: Dict[str, Any] = {}
+    checks: List[CheckResult] = []
+    for name, meta in tools.items():
+        start = time.perf_counter()
+        version = _version_of(meta["cmd"])
+        ok = version is not None
+        severity = "INFO" if ok else "MINOR"
+        hint = None if ok else f"Install {name} and ensure it is on PATH."
+        statuses[name] = {"present": ok, "version": version}
+        log_event(
+            event_id=EVENT_RANGES["preflight"][0] + 1,
+            level="INFO" if ok else "WARNING",
+            module="diagnostics.preflight",
+            op=f"tool_{name}",
+            duration_ms=(time.perf_counter() - start) * 1000,
+            ok=ok,
+            hint=hint,
+            working_dir=working_dir,
+        )
+        message = f"{name} detected" if ok else f"{name} missing"
+        checks.append(CheckResult(name=f"tool_{name}", ok=ok, severity=severity, message=message, hint=hint, data=statuses[name]))
+    return statuses, checks
+
+
+def _check_api_keys(settings: Dict[str, Any], *, working_dir: Path) -> Tuple[Dict[str, Any], List[CheckResult]]:
+    structure_cfg = settings.get("structure") if isinstance(settings.get("structure"), dict) else {}
+    tmdb_section = structure_cfg.get("tmdb") if isinstance(structure_cfg.get("tmdb"), dict) else {}
+    opensubs_section = structure_cfg.get("opensubtitles") if isinstance(structure_cfg.get("opensubtitles"), dict) else {}
+    tmdb_key = tmdb_section.get("api_key")
+    tmdb_present = bool((tmdb_key or os.environ.get("TMDB_API_KEY")) and str((tmdb_key or "").strip()))
+    opensubs_key = opensubs_section.get("api_key") or os.environ.get("OPENSUBTITLES_API_KEY")
+    opensubs_enabled = bool(opensubs_section.get("enabled", True))
+    opensubs_cached = False
+    cache_path = working_dir / "cache" / "opensubs_auth.json"
+    if cache_path.exists():
+        try:
+            payload = json.loads(cache_path.read_text(encoding="utf-8"))
+            opensubs_cached = bool(payload)
+        except Exception:
+            opensubs_cached = False
+    statuses = {
+        "tmdb_key_present": tmdb_present,
+        "opensubs_auth_ok": (not opensubs_enabled) or bool(opensubs_key) or opensubs_cached,
+    }
+    checks = [
+        CheckResult(
+            name="tmdb_api",
+            ok=tmdb_present,
+            severity="INFO" if tmdb_present else "MINOR",
+            message="TMDB API key configured" if tmdb_present else "TMDB API key missing",
+            hint=None if tmdb_present else "Set structure.tmdb.api_key or TMDB_API_KEY env.",
+            data={"present": tmdb_present},
+        ),
+    ]
+    if opensubs_enabled:
+        ok = bool(opensubs_key) or opensubs_cached
+        hint = None if ok else "Configure OpenSubtitles API key or disable integration."
+        checks.append(
+            CheckResult(
+                name="opensubs_api",
+                ok=ok,
+                severity="INFO" if ok else "MINOR",
+                message="OpenSubtitles auth cached" if ok else "OpenSubtitles auth missing",
+                hint=hint,
+                data={"cached": opensubs_cached, "key_present": bool(opensubs_key)},
+            )
+        )
+    else:
+        checks.append(
+            CheckResult(
+                name="opensubs_api",
+                ok=True,
+                severity="INFO",
+                message="OpenSubtitles disabled",
+                hint=None,
+                data={"cached": False, "key_present": False},
+            )
+        )
+    for idx, check in enumerate(checks, start=2):
+        log_event(
+            event_id=EVENT_RANGES["preflight"][0] + idx,
+            level="INFO" if check.ok else "WARNING",
+            module="diagnostics.preflight",
+            op=check.name,
+            ok=check.ok,
+            hint=check.hint,
+            extra=check.data,
+            working_dir=working_dir,
+        )
+    return statuses, checks
+
+
+def _check_fs(*, working_dir: Path) -> Tuple[Dict[str, Any], List[CheckResult]]:
+    logs_dir = get_logs_dir(working_dir)
+    writable = True
+    try:
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        test_file = logs_dir / ".diag_write_test"
+        with open(test_file, "w", encoding="utf-8") as handle:
+            handle.write("ok")
+        test_file.unlink(missing_ok=True)
+    except Exception:
+        writable = False
+    long_path_supported = os.name != "nt" or len(str(get_catalog_db_path(working_dir))) < 220
+    temp_dir = Path(tempfile.gettempdir())
+    try:
+        usage = shutil.disk_usage(temp_dir)
+        temp_space_gb = usage.free / (1024 ** 3)
+    except Exception:
+        temp_space_gb = None
+    statuses = {
+        "long_path_support": long_path_supported,
+        "working_dir_writable": writable,
+        "temp_space_gb": round(temp_space_gb, 2) if temp_space_gb is not None else None,
+    }
+    checks = [
+        CheckResult(
+            name="fs_workdir",
+            ok=writable,
+            severity="INFO" if writable else "MAJOR",
+            message="Working directory writable" if writable else "Working directory not writable",
+            hint=None if writable else f"Check permissions for {working_dir}",
+            data={"path": str(working_dir)},
+        ),
+        CheckResult(
+            name="fs_long_path",
+            ok=long_path_supported,
+            severity="INFO" if long_path_supported else "MINOR",
+            message="Long path safe" if long_path_supported else "Potential long path issues",
+            hint=None if long_path_supported else "Enable Windows long path support.",
+            data={"path": str(get_catalog_db_path(working_dir))},
+        ),
+    ]
+    if temp_space_gb is not None:
+        ok_temp = temp_space_gb >= 1.0
+        checks.append(
+            CheckResult(
+                name="fs_temp_space",
+                ok=ok_temp,
+                severity="INFO" if ok_temp else "MINOR",
+                message=f"Temp space {temp_space_gb:.1f} GiB" if ok_temp else "Low temp space",
+                hint=None if ok_temp else "Free disk space in system temp folder.",
+                data={"temp_dir": str(temp_dir), "temp_space_gb": round(temp_space_gb, 2)},
+            )
+        )
+    for idx, check in enumerate(checks, start=10):
+        log_event(
+            event_id=EVENT_RANGES["preflight"][0] + idx,
+            level="INFO" if check.ok else "WARNING",
+            module="diagnostics.preflight",
+            op=check.name,
+            ok=check.ok,
+            hint=check.hint,
+            extra=check.data,
+            working_dir=working_dir,
+        )
+    return statuses, checks
+
+
+def _check_db(*, working_dir: Path) -> Tuple[Dict[str, Any], List[CheckResult]]:
+    db_path = get_catalog_db_path(working_dir)
+    if not db_path.exists():
+        data = {"path": str(db_path), "exists": False}
+        check = CheckResult(
+            name="db_presence",
+            ok=False,
+            severity="MINOR",
+            message="Catalog database missing",
+            hint="Run a scan to create catalog.db",
+            data=data,
+        )
+        log_event(
+            event_id=EVENT_RANGES["preflight"][0] + 20,
+            level="WARNING",
+            module="diagnostics.preflight",
+            op="db_presence",
+            ok=False,
+            hint=check.hint,
+            extra=data,
+            working_dir=working_dir,
+        )
+        return data, [check]
+
+    try:
+        conn = core_db.connect(db_path, read_only=True, timeout=2.0)
+    except sqlite3.Error as exc:
+        data = {"path": str(db_path), "error": str(exc)}
+        check = CheckResult(
+            name="db_open",
+            ok=False,
+            severity="MAJOR",
+            message="Catalog DB inaccessible",
+            hint="Verify permissions and integrity.",
+            data=data,
+        )
+        log_event(
+            event_id=EVENT_RANGES["preflight"][0] + 21,
+            level="ERROR",
+            module="diagnostics.preflight",
+            op="db_open",
+            ok=False,
+            err_code="DB_OPEN_FAIL",
+            hint=check.hint,
+            extra=data,
+            working_dir=working_dir,
+        )
+        return data, [check]
+
+    checks: List[CheckResult] = []
+    data: Dict[str, Any] = {"path": str(db_path), "exists": True}
+    try:
+        conn.row_factory = sqlite3.Row
+        journal_mode = conn.execute("PRAGMA journal_mode").fetchone()
+        busy_timeout = conn.execute("PRAGMA busy_timeout").fetchone()
+        user_version = conn.execute("PRAGMA user_version").fetchone()
+        wal_enabled = str(journal_mode[0]).lower() == "wal" if journal_mode else False
+        busy_ok = int(busy_timeout[0]) >= core_db.DEFAULT_BUSY_TIMEOUT_MS if busy_timeout else False
+        schema_version = int(user_version[0]) if user_version else 0
+        data.update(
+            {
+                "wal_enabled": wal_enabled,
+                "busy_timeout_ms": int(busy_timeout[0]) if busy_timeout else None,
+                "schema_version": schema_version,
+            }
+        )
+        checks.append(
+            CheckResult(
+                name="db_wal",
+                ok=wal_enabled,
+                severity="MAJOR" if not wal_enabled else "INFO",
+                message="WAL enabled" if wal_enabled else "WAL disabled",
+                hint=None if wal_enabled else "Enable WAL mode for better concurrency.",
+                data={"wal": wal_enabled},
+            )
+        )
+        checks.append(
+            CheckResult(
+                name="db_busy_timeout",
+                ok=busy_ok,
+                severity="MINOR" if busy_ok else "MINOR",
+                message="busy_timeout configured" if busy_ok else "busy_timeout below recommended",
+                hint=None if busy_ok else "Increase busy_timeout to >=5000 ms.",
+                data={"busy_timeout_ms": data["busy_timeout_ms"]},
+            )
+        )
+    finally:
+        conn.close()
+    for idx, check in enumerate(checks, start=25):
+        log_event(
+            event_id=EVENT_RANGES["preflight"][0] + idx,
+            level="INFO" if check.ok else "WARNING",
+            module="diagnostics.preflight",
+            op=check.name,
+            ok=check.ok,
+            hint=check.hint,
+            extra=check.data,
+            working_dir=working_dir,
+        )
+    return data, checks
+
+
+def _check_settings(settings: Dict[str, Any], *, working_dir: Path) -> Tuple[Dict[str, Any], List[CheckResult]]:
+    unknown_keys = list(SETTINGS_VALIDATOR.unknown_keys(settings)) if isinstance(settings, dict) else []
+    diagnostics_section = settings.get("diagnostics") if isinstance(settings.get("diagnostics"), dict) else {}
+    timeouts = diagnostics_section.get("smoke_timeouts_s") if isinstance(diagnostics_section.get("smoke_timeouts_s"), dict) else {}
+    invalid_timeouts = [name for name, value in timeouts.items() if (not isinstance(value, (int, float)) or value <= 0)]
+    checks = []
+    checks.append(
+        CheckResult(
+            name="settings_unknown",
+            ok=not unknown_keys,
+            severity="INFO" if not unknown_keys else "MINOR",
+            message="Settings validated" if not unknown_keys else "Unknown settings keys detected",
+            hint=None if not unknown_keys else ", ".join(unknown_keys[:8]),
+            data={"unknown": unknown_keys},
+        )
+    )
+    checks.append(
+        CheckResult(
+            name="settings_timeouts",
+            ok=not invalid_timeouts,
+            severity="INFO" if not invalid_timeouts else "MINOR",
+            message="Smoke test timeouts valid" if not invalid_timeouts else "Invalid smoke test timeouts",
+            hint=None if not invalid_timeouts else f"Fix diagnostics.smoke_timeouts_s for {', '.join(invalid_timeouts)}",
+            data={"invalid_timeouts": invalid_timeouts},
+        )
+    )
+    for idx, check in enumerate(checks, start=40):
+        log_event(
+            event_id=EVENT_RANGES["preflight"][0] + idx,
+            level="INFO" if check.ok else "WARNING",
+            module="diagnostics.preflight",
+            op=check.name,
+            ok=check.ok,
+            hint=check.hint,
+            extra=check.data,
+            working_dir=working_dir,
+        )
+    return {"unknown_keys": unknown_keys, "invalid_timeouts": invalid_timeouts}, checks
+
+
+def run_preflight(*, working_dir: Optional[Path] = None) -> Dict[str, Any]:
+    """Run preflight diagnostics and return a structured payload."""
+
+    resolved_working_dir = working_dir or resolve_working_dir()
+    settings = load_settings(resolved_working_dir) or {}
+    diag_settings = settings.get("diagnostics") if isinstance(settings.get("diagnostics"), dict) else {}
+    keep_days = int(diag_settings.get("logs_keep_days", 14)) if diag_settings else 14
+
+    purge_old_logs(keep_days=keep_days, working_dir=resolved_working_dir)
+
+    sections: Dict[str, Dict[str, Any]] = {}
+    checks: List[CheckResult] = []
+
+    gpu_ready, gpu_section, gpu_check = _check_gpu(settings=settings, working_dir=resolved_working_dir)
+    sections["gpu"] = gpu_section
+    checks.append(gpu_check)
+
+    tools_section, tool_checks = _check_tools(working_dir=resolved_working_dir)
+    sections["tools"] = tools_section
+    checks.extend(tool_checks)
+
+    api_section, api_checks = _check_api_keys(settings, working_dir=resolved_working_dir)
+    sections["apis"] = api_section
+    checks.extend(api_checks)
+
+    fs_section, fs_checks = _check_fs(working_dir=resolved_working_dir)
+    sections["fs"] = fs_section
+    checks.extend(fs_checks)
+
+    db_section, db_checks = _check_db(working_dir=resolved_working_dir)
+    sections["db"] = db_section
+    checks.extend(db_checks)
+
+    settings_section, settings_checks = _check_settings(settings, working_dir=resolved_working_dir)
+    sections["settings"] = settings_section
+    checks.extend(settings_checks)
+
+    result = PreflightResult(ts=time.time(), gpu_ready=gpu_ready, sections=sections, checks=checks)
+    payload = {
+        "ts": result.ts,
+        "gpu_ready": result.gpu_ready,
+        "summary": result.summary(),
+        "sections": sections,
+        "checks": [
+            {
+                "name": check.name,
+                "ok": check.ok,
+                "severity": check.severity,
+                "message": check.message,
+                "hint": check.hint,
+                "data": check.data,
+            }
+            for check in checks
+        ],
+    }
+    persist_snapshot("preflight", payload, working_dir=resolved_working_dir)
+    return payload
+
+
+__all__ = ["run_preflight"]

--- a/diagnostics/report.py
+++ b/diagnostics/report.py
@@ -1,0 +1,90 @@
+"""Aggregate diagnostics reports and export bundles."""
+from __future__ import annotations
+
+import json
+import time
+import zipfile
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from core.paths import get_exports_dir, resolve_working_dir
+
+from .logs import (
+    EVENT_RANGES,
+    latest_preflight_path,
+    latest_smoke_path,
+    load_snapshot,
+    log_event,
+    query_logs,
+)
+
+
+def _ensure_export_dir(working_dir: Path) -> Path:
+    exports_dir = get_exports_dir(working_dir) / "diagnostics"
+    exports_dir.mkdir(parents=True, exist_ok=True)
+    return exports_dir
+
+
+def build_report_snapshot(
+    *,
+    preflight: Optional[Dict[str, Any]] = None,
+    smoke: Optional[Dict[str, Any]] = None,
+    working_dir: Optional[Path] = None,
+) -> Dict[str, Any]:
+    resolved = working_dir or resolve_working_dir()
+    preflight_payload = preflight or load_snapshot("preflight", working_dir=resolved) or {}
+    smoke_payload = smoke or load_snapshot("smoke", working_dir=resolved) or {}
+    summary = {
+        "preflight": preflight_payload.get("summary", {}),
+        "smoke": smoke_payload.get("summary", {}),
+    }
+    return {
+        "ts": time.time(),
+        "summary": summary,
+        "preflight": preflight_payload,
+        "smoke": smoke_payload,
+    }
+
+
+def export_report_bundle(
+    *,
+    preflight: Optional[Dict[str, Any]] = None,
+    smoke: Optional[Dict[str, Any]] = None,
+    logs_limit: int = 500,
+    working_dir: Optional[Path] = None,
+) -> Path:
+    resolved = working_dir or resolve_working_dir()
+    snapshot = build_report_snapshot(preflight=preflight, smoke=smoke, working_dir=resolved)
+    logs_payload = query_logs(limit=logs_limit, working_dir=resolved)
+
+    exports_dir = _ensure_export_dir(resolved)
+    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    bundle_path = exports_dir / f"diagnostics_{timestamp}.zip"
+
+    with zipfile.ZipFile(bundle_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("report.json", json.dumps(snapshot, indent=2, ensure_ascii=False))
+        archive.writestr("preflight.json", json.dumps(snapshot.get("preflight", {}), indent=2, ensure_ascii=False))
+        archive.writestr("smoke.json", json.dumps(snapshot.get("smoke", {}), indent=2, ensure_ascii=False))
+        archive.writestr("logs.json", json.dumps(logs_payload, indent=2, ensure_ascii=False))
+        preflight_path = latest_preflight_path(resolved)
+        smoke_path = latest_smoke_path(resolved)
+        if preflight_path.exists():
+            archive.write(preflight_path, arcname=f"snapshots/{preflight_path.name}")
+        if smoke_path.exists():
+            archive.write(smoke_path, arcname=f"snapshots/{smoke_path.name}")
+
+    log_event(
+        event_id=EVENT_RANGES["smoke"][0] + 500,
+        level="INFO",
+        module="diagnostics.report",
+        op="export_report",
+        ok=True,
+        working_dir=resolved,
+        extra={"path": str(bundle_path)},
+    )
+
+    return bundle_path
+
+
+__all__ = ["build_report_snapshot", "export_report_bundle"]

--- a/diagnostics/smoke.py
+++ b/diagnostics/smoke.py
@@ -1,0 +1,458 @@
+"""Smoke tests for VideoCatalog subsystems."""
+from __future__ import annotations
+
+import io
+import json
+import sqlite3
+import subprocess
+import tempfile
+import time
+from concurrent.futures import ThreadPoolExecutor, TimeoutError
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+
+# Optional dependency for visual smoke test
+try:  # pragma: no cover - optional dependency
+    from PIL import Image
+except Exception:  # pragma: no cover - optional dependency
+    Image = None  # type: ignore[assignment]
+
+from core.paths import get_catalog_db_path, resolve_working_dir
+from core.settings import load_settings
+
+from .logs import EVENT_RANGES, log_event, persist_snapshot
+
+
+@dataclass(slots=True)
+class SmokeCheck:
+    name: str
+    ok: bool
+    severity: str
+    message: str
+    hint: Optional[str] = None
+    duration_ms: float = 0.0
+    data: Dict[str, Any] = field(default_factory=dict)
+
+
+DEFAULT_SUBSYSTEMS = [
+    "movies_structure",
+    "tv_structure",
+    "apiguard_cache",
+    "visualreview",
+    "docs_textlite",
+    "assistant_tools",
+]
+
+
+def _load_timeout(settings: Dict[str, Any], key: str, default: float = 10.0) -> float:
+    diag = settings.get("diagnostics") if isinstance(settings.get("diagnostics"), dict) else {}
+    timeouts = diag.get("smoke_timeouts_s") if isinstance(diag.get("smoke_timeouts_s"), dict) else {}
+    value = timeouts.get(key, default)
+    try:
+        numeric = float(value)
+        return numeric if numeric > 0 else default
+    except Exception:
+        return default
+
+
+def _sample_size(settings: Dict[str, Any], key: str, default: int = 5) -> int:
+    diag = settings.get("diagnostics") if isinstance(settings.get("diagnostics"), dict) else {}
+    samples = diag.get("sample_sizes") if isinstance(diag.get("sample_sizes"), dict) else {}
+    try:
+        return max(1, int(samples.get(key, default)))
+    except Exception:
+        return default
+
+
+def _movies_structure(settings: Dict[str, Any], working_dir: Path) -> SmokeCheck:
+    db_path = get_catalog_db_path(working_dir)
+    if not db_path.exists():
+        return SmokeCheck(
+            name="movies_structure",
+            ok=True,
+            severity="INFO",
+            message="Catalog DB missing; movies smoke skipped.",
+        )
+    sample = _sample_size(settings, "movies")
+    start = time.perf_counter()
+    try:
+        conn = sqlite3.connect(f"file:{db_path.as_posix()}?mode=ro", uri=True, timeout=2.0)
+    except sqlite3.Error as exc:
+        return SmokeCheck(
+            name="movies_structure",
+            ok=False,
+            severity="MAJOR",
+            message="Failed to open catalog for movies smoke test",
+            hint=str(exc),
+        )
+    try:
+        try:
+            rows = conn.execute(
+                "SELECT folder_path, confidence FROM folder_profile ORDER BY updated_utc DESC LIMIT ?",
+                (sample,),
+            ).fetchall()
+        except sqlite3.DatabaseError:
+            rows = []
+        if not rows:
+            return SmokeCheck(
+                name="movies_structure",
+                ok=True,
+                severity="INFO",
+                message="No folder_profile rows yet",
+                duration_ms=(time.perf_counter() - start) * 1000,
+            )
+        confidences = [row[1] for row in rows if row[1] is not None]
+        avg_conf = sum(confidences) / len(confidences) if confidences else None
+        low = [row[0] for row in rows if row[1] is not None and row[1] < 0.5]
+        ok = len(low) < max(1, len(rows) // 2)
+        return SmokeCheck(
+            name="movies_structure",
+            ok=ok,
+            severity="INFO" if ok else "MINOR",
+            message="Movies profile healthy" if ok else "Many low-confidence movie folders",
+            hint=None if ok else "Review structure queue for low-confidence movies.",
+            duration_ms=(time.perf_counter() - start) * 1000,
+            data={"rows": len(rows), "low_conf": len(low), "avg_conf": avg_conf},
+        )
+    finally:
+        conn.close()
+
+
+def _tv_structure(settings: Dict[str, Any], working_dir: Path) -> SmokeCheck:
+    db_path = get_catalog_db_path(working_dir)
+    if not db_path.exists():
+        return SmokeCheck(
+            name="tv_structure",
+            ok=True,
+            severity="INFO",
+            message="Catalog DB missing; TV smoke skipped.",
+        )
+    sample = _sample_size(settings, "tv")
+    start = time.perf_counter()
+    try:
+        conn = sqlite3.connect(f"file:{db_path.as_posix()}?mode=ro", uri=True, timeout=2.0)
+    except sqlite3.Error as exc:
+        return SmokeCheck(
+            name="tv_structure",
+            ok=False,
+            severity="MAJOR",
+            message="Failed to open catalog for TV smoke test",
+            hint=str(exc),
+        )
+    try:
+        try:
+            rows = conn.execute(
+                "SELECT episode_path, season_number, episode_numbers_json, confidence FROM tv_episode_profile ORDER BY updated_utc DESC LIMIT ?",
+                (sample,),
+            ).fetchall()
+        except sqlite3.DatabaseError:
+            rows = []
+        if not rows:
+            return SmokeCheck(
+                name="tv_structure",
+                ok=True,
+                severity="INFO",
+                message="No tv_episode_profile rows yet",
+                duration_ms=(time.perf_counter() - start) * 1000,
+            )
+        inconsistent = 0
+        for row in rows:
+            try:
+                payload = json.loads(row[2] or "[]")
+            except json.JSONDecodeError:
+                inconsistent += 1
+                continue
+            if not payload:
+                inconsistent += 1
+        ok = inconsistent == 0
+        return SmokeCheck(
+            name="tv_structure",
+            ok=ok,
+            severity="INFO" if ok else "MINOR",
+            message="TV episodes look consistent" if ok else "TV episodes missing numbering",
+            hint=None if ok else "Re-run structure profiler for affected shows.",
+            duration_ms=(time.perf_counter() - start) * 1000,
+            data={"rows": len(rows), "inconsistent": inconsistent},
+        )
+    finally:
+        conn.close()
+
+
+def _apiguard_cache(settings: Dict[str, Any], working_dir: Path) -> SmokeCheck:
+    cache_path = working_dir / "cache" / "tmdb_cache.json"
+    if not cache_path.exists():
+        return SmokeCheck(
+            name="apiguard_cache",
+            ok=True,
+            severity="INFO",
+            message="TMDB cache empty",
+        )
+    try:
+        payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return SmokeCheck(
+            name="apiguard_cache",
+            ok=False,
+            severity="MINOR",
+            message="TMDB cache unreadable",
+            hint=str(exc),
+        )
+    entries = payload.get("entries") if isinstance(payload, dict) else {}
+    ok = isinstance(entries, dict)
+    cache_size = len(entries) if isinstance(entries, dict) else 0
+    return SmokeCheck(
+        name="apiguard_cache",
+        ok=ok,
+        severity="INFO" if ok else "MINOR",
+        message=f"TMDB cache has {cache_size} entries" if ok else "TMDB cache corrupted",
+        hint=None if ok else "Delete cache/tmdb_cache.json and retry",
+        data={"cache_size": cache_size},
+    )
+
+
+def _visualreview(settings: Dict[str, Any], working_dir: Path) -> SmokeCheck:
+    if Image is None:
+        return SmokeCheck(
+            name="visualreview",
+            ok=False,
+            severity="MINOR",
+            message="Pillow not available for visual smoke test",
+            hint="Install pillow package.",
+        )
+    timeout = _load_timeout(settings, "visual", 10.0)
+    start = time.perf_counter()
+    command = [
+        "ffmpeg",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-f",
+        "lavfi",
+        "-i",
+        "color=c=black:s=64x64:d=0.2",
+        "-frames:v",
+        "1",
+        "-f",
+        "image2pipe",
+        "-vcodec",
+        "png",
+        "-",
+    ]
+    try:
+        proc = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=timeout, check=False)
+    except FileNotFoundError:
+        return SmokeCheck(
+            name="visualreview",
+            ok=False,
+            severity="MINOR",
+            message="ffmpeg not available for visual review",
+            hint="Install ffmpeg to enable visual review features.",
+        )
+    except subprocess.TimeoutExpired:
+        return SmokeCheck(
+            name="visualreview",
+            ok=False,
+            severity="MINOR",
+            message="ffmpeg timed out generating preview",
+            hint="Check ffmpeg installation and GPU availability.",
+        )
+    if proc.returncode != 0 or not proc.stdout:
+        return SmokeCheck(
+            name="visualreview",
+            ok=False,
+            severity="MINOR",
+            message="ffmpeg failed to produce preview frame",
+            hint=proc.stderr.decode("utf-8", "ignore")[:200],
+        )
+    try:
+        image = Image.open(io.BytesIO(proc.stdout))
+        contact = Image.new("RGB", image.size, color=(20, 20, 20))
+        contact.paste(image, (0, 0))
+    except Exception as exc:
+        return SmokeCheck(
+            name="visualreview",
+            ok=False,
+            severity="MINOR",
+            message="Failed to assemble contact sheet",
+            hint=str(exc),
+        )
+    return SmokeCheck(
+        name="visualreview",
+        ok=True,
+        severity="INFO",
+        message="Visual review ffmpeg pipeline ok",
+        duration_ms=(time.perf_counter() - start) * 1000,
+        data={"frame_size": image.size},
+    )
+
+
+def _docs_textlite(settings: Dict[str, Any], working_dir: Path) -> SmokeCheck:
+    sample = _sample_size(settings, "docs", 3)
+    start = time.perf_counter()
+    conn = sqlite3.connect(":memory:")
+    from textlite.store import PreviewRow, ensure_tables, upsert_many
+
+    ensure_tables(conn)
+    rows = [
+        PreviewRow(path=f"diagnostics://sample/{idx}", kind="text", bytes_sampled=42, lines_sampled=5, summary="ok", keywords=["demo"], schema_json=None)
+        for idx in range(sample)
+    ]
+    try:
+        upsert_many(conn, rows)
+        cur = conn.execute("SELECT COUNT(*) FROM textlite_preview")
+        count = cur.fetchone()[0]
+        fts_count = conn.execute("SELECT COUNT(*) FROM textlite_fts").fetchone()[0]
+        ok = count == sample and fts_count == sample
+        return SmokeCheck(
+            name="docs_textlite",
+            ok=ok,
+            severity="INFO" if ok else "MINOR",
+            message="TextLite preview pipeline ok" if ok else "TextLite FTS mismatch",
+            hint=None if ok else "Check textlite_preview/textlite_fts tables",
+            duration_ms=(time.perf_counter() - start) * 1000,
+            data={"count": count, "fts": fts_count},
+        )
+    finally:
+        conn.close()
+
+
+def _assistant_tools(settings: Dict[str, Any], working_dir: Path) -> SmokeCheck:
+    db_path = get_catalog_db_path(working_dir)
+    if not db_path.exists():
+        return SmokeCheck(
+            name="assistant_tools",
+            ok=True,
+            severity="INFO",
+            message="Catalog DB missing; assistant tool smoke skipped.",
+        )
+    start = time.perf_counter()
+    try:
+        conn = sqlite3.connect(f"file:{db_path.as_posix()}?mode=ro", uri=True, timeout=2.0)
+    except sqlite3.Error as exc:
+        return SmokeCheck(
+            name="assistant_tools",
+            ok=False,
+            severity="MAJOR",
+            message="Failed to open catalog for assistant tools",
+            hint=str(exc),
+        )
+    try:
+        tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+        if "tv_episode_profile" not in tables:
+            return SmokeCheck(
+                name="assistant_tools",
+                ok=True,
+                severity="INFO",
+                message="assistant low-confidence query skipped (table missing)",
+                duration_ms=(time.perf_counter() - start) * 1000,
+            )
+        rows = conn.execute(
+            "SELECT COUNT(*) FROM tv_episode_profile WHERE confidence IS NULL OR confidence < 0.4"
+        ).fetchone()
+        low_conf = rows[0] if rows else 0
+        ok = True
+        severity = "INFO" if low_conf < 5 else "MINOR"
+        message = "Assistant tool query ok" if severity == "INFO" else "Assistant reports many low-confidence episodes"
+        return SmokeCheck(
+            name="assistant_tools",
+            ok=ok,
+            severity=severity,
+            message=message,
+            duration_ms=(time.perf_counter() - start) * 1000,
+            data={"low_conf": int(low_conf)},
+        )
+    finally:
+        conn.close()
+
+
+_TEST_REGISTRY: Dict[str, Callable[[Dict[str, Any], Path], SmokeCheck]] = {
+    "movies_structure": _movies_structure,
+    "tv_structure": _tv_structure,
+    "apiguard_cache": _apiguard_cache,
+    "visualreview": _visualreview,
+    "docs_textlite": _docs_textlite,
+    "assistant_tools": _assistant_tools,
+}
+
+
+def run_smoke_tests(
+    subsystems: Optional[Iterable[str]] = None,
+    *,
+    budget: Optional[int] = None,
+    working_dir: Optional[Path] = None,
+) -> Dict[str, Any]:
+    resolved_working_dir = working_dir or resolve_working_dir()
+    settings = load_settings(resolved_working_dir) or {}
+    selected = [name for name in (subsystems or DEFAULT_SUBSYSTEMS) if name in _TEST_REGISTRY]
+    if budget is not None:
+        selected = selected[: max(1, int(budget))]
+
+    results: List[SmokeCheck] = []
+    for index, name in enumerate(selected):
+        test = _TEST_REGISTRY[name]
+        timeout = _load_timeout(settings, name.split("_")[0] if "_" in name else name)
+        start = time.perf_counter()
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(test, settings, resolved_working_dir)
+            try:
+                check = future.result(timeout=timeout)
+            except TimeoutError:
+                check = SmokeCheck(
+                    name=name,
+                    ok=False,
+                    severity="MINOR",
+                    message=f"Smoke test {name} timed out",
+                    hint=f"Increase diagnostics.smoke_timeouts_s.{name} if necessary",
+                )
+            except Exception as exc:  # pragma: no cover - defensive
+                check = SmokeCheck(
+                    name=name,
+                    ok=False,
+                    severity="MAJOR",
+                    message=f"Smoke test {name} crashed",
+                    hint=str(exc),
+                )
+        if check.duration_ms <= 0:
+            check.duration_ms = (time.perf_counter() - start) * 1000
+        results.append(check)
+        log_event(
+            event_id=EVENT_RANGES["smoke"][0] + index,
+            level="INFO" if check.ok else "WARNING",
+            module="diagnostics.smoke",
+            op=name,
+            duration_ms=check.duration_ms,
+            ok=check.ok,
+            hint=check.hint,
+            extra=check.data,
+            working_dir=resolved_working_dir,
+        )
+
+    summary = {"MAJOR": 0, "MINOR": 0, "INFO": 0}
+    for check in results:
+        if check.ok:
+            continue
+        severity = check.severity.upper()
+        summary[severity] = summary.get(severity, 0) + 1
+
+    payload = {
+        "ts": time.time(),
+        "summary": summary,
+        "checks": [
+            {
+                "name": check.name,
+                "ok": check.ok,
+                "severity": check.severity,
+                "message": check.message,
+                "hint": check.hint,
+                "duration_ms": check.duration_ms,
+                "data": check.data,
+            }
+            for check in results
+        ],
+    }
+    persist_snapshot("smoke", payload, working_dir=resolved_working_dir)
+    return payload
+
+
+__all__ = ["run_smoke_tests", "DEFAULT_SUBSYSTEMS"]

--- a/diagnostics/tools.py
+++ b/diagnostics/tools.py
@@ -1,0 +1,129 @@
+"""Read-only diagnostics tools exposed to the assistant runtime."""
+from __future__ import annotations
+
+import statistics
+import time
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from core.paths import get_catalog_db_path, resolve_working_dir
+from core.settings import load_settings
+
+from .logs import load_snapshot, query_logs
+from .preflight import run_preflight
+from .report import build_report_snapshot
+from .smoke import DEFAULT_SUBSYSTEMS, run_smoke_tests
+
+
+class DiagnosticsTools:
+    """Convenience wrapper to expose diagnostics operations to LLM tools."""
+
+    def __init__(self, working_dir: Optional[Path] = None) -> None:
+        self.working_dir = working_dir or resolve_working_dir()
+        self.settings = load_settings(self.working_dir) or {}
+        self.db_path = get_catalog_db_path(self.working_dir)
+
+    # ------------------------------------------------------------------
+    def diag_run_preflight(self) -> Dict[str, Any]:
+        return run_preflight(working_dir=self.working_dir)
+
+    def diag_run_smoke(
+        self,
+        subsystems: Optional[Iterable[str]] = None,
+        budget: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        allowed = [name for name in (subsystems or DEFAULT_SUBSYSTEMS) if name in DEFAULT_SUBSYSTEMS]
+        return run_smoke_tests(allowed, budget=budget, working_dir=self.working_dir)
+
+    def diag_get_logs(self, query: Optional[Dict[str, Any]] = None, limit: int = 200) -> Dict[str, Any]:
+        return query_logs(query=query, limit=limit, working_dir=self.working_dir)
+
+    def diag_get_metrics(self, window_min: int = 60) -> Dict[str, Any]:
+        payload = query_logs(limit=2000, working_dir=self.working_dir)
+        now = time.time()
+        threshold = now - max(1, int(window_min)) * 60
+        durations: List[float] = []
+        cache_hits = 0
+        cache_total = 0
+        budget_events = 0
+        logs = []
+        for row in payload.get("rows", []):
+            ts = float(row.get("ts", 0))
+            if ts < threshold:
+                continue
+            logs.append(row)
+            duration = row.get("duration_ms")
+            if isinstance(duration, (int, float)):
+                durations.append(float(duration))
+            if row.get("module") == "diagnostics.smoke" and "cache_size" in row:
+                cache_total += 1
+                if row.get("cache_size"):
+                    cache_hits += 1
+            if row.get("module") == "diagnostics.preflight" and row.get("op") == "gpu":
+                budget_events += 1
+        metrics = {}
+        if durations:
+            metrics["duration_ms"] = {
+                "p50": round(statistics.median(durations), 2),
+                "p90": round(statistics.quantiles(durations, n=10)[8], 2) if len(durations) >= 10 else round(max(durations), 2),
+                "p95": round(statistics.quantiles(durations, n=20)[18], 2) if len(durations) >= 20 else round(max(durations), 2),
+            }
+        if cache_total:
+            metrics["cache_hit_ratio"] = round(cache_hits / cache_total, 3)
+        metrics["gpu_checks"] = budget_events
+        return {"window_min": window_min, "metrics": metrics, "samples": len(logs)}
+
+    def diag_sql(self, view: str, where: Optional[Dict[str, Any]] = None, limit: int = 50) -> Dict[str, Any]:
+        view = (view or "").lower()
+        limit = max(1, min(500, int(limit)))
+        rows: List[Dict[str, Any]]
+        if view == "preflight_checks":
+            snapshot = load_snapshot("preflight", working_dir=self.working_dir) or {}
+            rows = [
+                {
+                    "name": check.get("name"),
+                    "ok": check.get("ok"),
+                    "severity": check.get("severity"),
+                    "message": check.get("message"),
+                    "hint": check.get("hint"),
+                    **(check.get("data") or {}),
+                }
+                for check in snapshot.get("checks", [])
+            ]
+        elif view == "smoke_checks":
+            snapshot = load_snapshot("smoke", working_dir=self.working_dir) or {}
+            rows = [
+                {
+                    "name": check.get("name"),
+                    "ok": check.get("ok"),
+                    "severity": check.get("severity"),
+                    "message": check.get("message"),
+                    "hint": check.get("hint"),
+                    "duration_ms": check.get("duration_ms"),
+                    **(check.get("data") or {}),
+                }
+                for check in snapshot.get("checks", [])
+            ]
+        elif view == "log_events":
+            payload = query_logs(limit=limit, working_dir=self.working_dir)
+            rows = list(payload.get("rows", []))
+        else:
+            raise ValueError("Unsupported diagnostics view")
+        if where:
+            filtered = []
+            for row in rows:
+                include = True
+                for key, value in where.items():
+                    if str(row.get(key)) != str(value):
+                        include = False
+                        break
+                if include:
+                    filtered.append(row)
+            rows = filtered
+        return {"rows": rows[:limit], "count": min(len(rows), limit)}
+
+    def diag_get_report(self) -> Dict[str, Any]:
+        return build_report_snapshot(working_dir=self.working_dir)
+
+
+__all__ = ["DiagnosticsTools"]


### PR DESCRIPTION
## Summary
- implement the diagnostics package with preflight checks, smoke tests, structured logging, reports, and read-only tools
- integrate GPU hard requirement handling with the Debug tab UI and wire diagnostics events into the GUI
- expose diag_* assistant tools and seed default diagnostics settings

## Testing
- python -m compileall diagnostics DiskScannerGUI.py

------
https://chatgpt.com/codex/tasks/task_e_68ea6dcca928832799ae26c46466a76e