### PR TITLE
Add evening playlist API and UI workflow

### DIFF
--- a/web/catalog-ui/src/api/client.ts
+++ b/web/catalog-ui/src/api/client.ts
@@ -11,10 +11,17 @@ import type {
   SearchResponse,
   SeriesRow,
   SeasonRow,
+  PlaylistAiResponse,
+  PlaylistBuildResponse,
+  PlaylistExportPayload,
+  PlaylistExportResponse,
+  PlaylistOrderMode,
+  PlaylistSuggestResponse,
 } from './types';
 
 const API_BASE = '/v1/catalog';
 const ASSISTANT_BASE = '/v1/assistant';
+const PLAYLIST_BASE = '/v1/playlist';
 
 export function getStoredApiKey(): string | null {
   try {
@@ -101,6 +108,52 @@ export async function openFolder(path: string): Promise<{ plan: string; path: st
   return fetchJson<{ plan: string; path: string }>(`${API_BASE}/open-folder`, {
     method: 'POST',
     body: JSON.stringify({ path }),
+  });
+}
+
+export async function getPlaylistSuggestions(
+  params: Record<string, unknown>,
+): Promise<PlaylistSuggestResponse> {
+  const query = buildQuery(params);
+  return fetchJson<PlaylistSuggestResponse>(`${PLAYLIST_BASE}/suggest${query}`);
+}
+
+export async function buildPlaylist(body: {
+  items: string[];
+  mode?: PlaylistOrderMode;
+  target_minutes?: number | null;
+}): Promise<PlaylistBuildResponse> {
+  return fetchJson<PlaylistBuildResponse>(`${PLAYLIST_BASE}/build`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+export async function exportPlaylist(body: {
+  name: string;
+  format: 'm3u' | 'csv';
+  items: PlaylistExportPayload[];
+}): Promise<PlaylistExportResponse> {
+  return fetchJson<PlaylistExportResponse>(`${PLAYLIST_BASE}/export`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+export async function openPlaylistFolder(path: string): Promise<{ plan: string; path: string }> {
+  return fetchJson<{ plan: string; path: string }>(`${PLAYLIST_BASE}/open-folder`, {
+    method: 'POST',
+    body: JSON.stringify({ path }),
+  });
+}
+
+export async function requestPlaylistAi(
+  question: string,
+  constraints: Record<string, unknown>,
+): Promise<PlaylistAiResponse> {
+  return fetchJson<PlaylistAiResponse>(`${PLAYLIST_BASE}/ai`, {
+    method: 'POST',
+    body: JSON.stringify({ question, constraints }),
   });
 }
 

--- a/web/catalog-ui/src/api/types.ts
+++ b/web/catalog-ui/src/api/types.ts
@@ -157,6 +157,81 @@ export interface AssistantStatus {
   runtime?: Record<string, unknown>;
 }
 
+export type PlaylistOrderMode = 'weighted' | 'sort_quality' | 'sort_confidence';
+
+export interface PlaylistCandidateRow {
+  id: string;
+  kind: 'movie' | 'episode' | string;
+  drive?: string | null;
+  path: string;
+  masked_path: string;
+  title?: string;
+  year?: number;
+  duration_min?: number | null;
+  quality?: number | null;
+  confidence: number;
+  langs_audio: string[];
+  langs_subs: string[];
+  subs_present: boolean;
+  genres: string[];
+}
+
+export interface PlaylistSuggestResponse {
+  limit: number;
+  candidates: PlaylistCandidateRow[];
+}
+
+export interface PlaylistBuildItemRow {
+  id: string;
+  kind: 'movie' | 'episode' | string;
+  drive?: string | null;
+  title?: string;
+  year?: number;
+  duration_min?: number | null;
+  cumulative_minutes: number;
+  path: string;
+  masked_path: string;
+  quality?: number | null;
+  confidence: number;
+  langs_audio: string[];
+  langs_subs: string[];
+  subs_present: boolean;
+  open_plan: { plan: string; path: string };
+}
+
+export interface PlaylistBuildResponse {
+  mode: PlaylistOrderMode;
+  target_minutes?: number | null;
+  total_minutes: number;
+  items: PlaylistBuildItemRow[];
+}
+
+export interface PlaylistExportPayload {
+  path: string;
+  title?: string;
+}
+
+export interface PlaylistExportResponse {
+  ok: boolean;
+  format: 'm3u' | 'csv';
+  path: string;
+  count: number;
+}
+
+export interface PlaylistAiPlanItem {
+  id: string;
+  reason?: string;
+  confidence?: number;
+  quality?: number | null;
+}
+
+export interface PlaylistAiResponse {
+  mode: string;
+  items: PlaylistAiPlanItem[];
+  reasoning: string;
+  sources: string[];
+}
+
 export interface AssistantAskSource {
   type: string;
   ref: string;

--- a/web/catalog-ui/src/components/AppShell.tsx
+++ b/web/catalog-ui/src/components/AppShell.tsx
@@ -12,6 +12,7 @@ const NAV_LINKS = [
   { to: '/movies', label: 'Movies' },
   { to: '/tv', label: 'TV' },
   { to: '/search', label: 'Search' },
+  { to: '/playlist', label: 'Evening Playlist' },
 ];
 
 interface AppShellProps {

--- a/web/catalog-ui/src/components/PlaylistDrawer.module.css
+++ b/web/catalog-ui/src/components/PlaylistDrawer.module.css
@@ -1,0 +1,294 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(7, 12, 18, 0.68);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+  display: flex;
+  justify-content: flex-end;
+  z-index: 80;
+}
+
+.overlayVisible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.drawer {
+  width: min(720px, 100%);
+  background: rgba(12, 18, 26, 0.96);
+  color: #f8fafc;
+  height: 100%;
+  transform: translateX(100%);
+  transition: transform 0.3s ease;
+  position: relative;
+  box-shadow: -24px 0 64px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem 2rem;
+  overflow: hidden;
+}
+
+.drawerVisible {
+  transform: translateX(0);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.closeButton {
+  border: none;
+  background: rgba(255, 255, 255, 0.12);
+  color: #f8fafc;
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  font-size: 1.25rem;
+  cursor: pointer;
+}
+
+.body {
+  display: grid;
+  grid-template-columns: minmax(260px, 1fr) 240px;
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+  overflow-y: auto;
+  padding-bottom: 1rem;
+}
+
+.filters {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.filterRow {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.filterRow label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(248, 250, 252, 0.66);
+}
+
+.filterRow input,
+.filterRow select {
+  background: rgba(15, 23, 42, 0.72);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  color: #f8fafc;
+  border-radius: 10px;
+  padding: 0.45rem 0.75rem;
+  font-size: 0.95rem;
+}
+
+.inlineInputs {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.actionsRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.25rem;
+}
+
+.primaryButton,
+.secondaryButton {
+  padding: 0.6rem 1.3rem;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.primaryButton {
+  background: linear-gradient(135deg, #38bdf8, #818cf8);
+  color: #0f172a;
+}
+
+.secondaryButton {
+  background: rgba(148, 163, 184, 0.14);
+  color: #f8fafc;
+}
+
+.primaryButton:disabled,
+.secondaryButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.sidebar {
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-radius: 16px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-height: 0;
+}
+
+.selectionSummary {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.selectionList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 220px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.selectionItem {
+  width: 100%;
+  text-align: left;
+  border: none;
+  background: rgba(148, 163, 184, 0.12);
+  border-radius: 12px;
+  padding: 0.5rem 0.75rem;
+  color: #f8fafc;
+  cursor: pointer;
+}
+
+.selectionMeta {
+  font-size: 0.75rem;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.linkButton {
+  border: none;
+  background: none;
+  color: #60a5fa;
+  cursor: pointer;
+  padding: 0.25rem 0;
+  font-size: 0.85rem;
+}
+
+.aiPlanBox {
+  margin-top: 0.5rem;
+  padding: 0.75rem;
+  border-radius: 14px;
+  background: rgba(30, 41, 59, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.results {
+  flex: 1;
+  overflow-y: auto;
+  padding-top: 1.5rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.16);
+  margin-top: 1rem;
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 1rem;
+  margin-bottom: 0.6rem;
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.playlistList,
+.suggestionList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.playlistItem {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 16px;
+  padding: 0.85rem 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.playlistMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  font-size: 0.78rem;
+  color: rgba(203, 213, 225, 0.75);
+  margin-top: 0.35rem;
+}
+
+.badges {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.45rem;
+}
+
+.badge {
+  padding: 0.25rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.badge-good {
+  background: rgba(34, 197, 94, 0.15);
+  color: #34d399;
+}
+
+.badge-warn {
+  background: rgba(234, 179, 8, 0.15);
+  color: #fbbf24;
+}
+
+.badge-critical {
+  background: rgba(248, 113, 113, 0.15);
+  color: #f87171;
+}
+
+.error {
+  color: #f87171;
+  margin-bottom: 0.75rem;
+}
+
+.notice {
+  color: #34d399;
+  margin-bottom: 0.75rem;
+}
+
+.placeholder {
+  color: rgba(148, 163, 184, 0.75);
+  font-style: italic;
+}
+
+@media (max-width: 960px) {
+  .body {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .sidebar {
+    order: -1;
+  }
+}

--- a/web/catalog-ui/src/components/PlaylistDrawer.tsx
+++ b/web/catalog-ui/src/components/PlaylistDrawer.tsx
@@ -1,0 +1,568 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import clsx from 'clsx';
+
+import {
+  buildPlaylist,
+  exportPlaylist,
+  getPlaylistSuggestions,
+  openPlaylistFolder,
+  requestPlaylistAi,
+} from '../api/client';
+import type {
+  PlaylistAiResponse,
+  PlaylistBuildItemRow,
+  PlaylistBuildResponse,
+  PlaylistCandidateRow,
+  PlaylistOrderMode,
+} from '../api/types';
+import { useAssistantStatus } from '../hooks/useAssistantStatus';
+import { usePlaylist } from '../hooks/usePlaylist';
+import styles from './PlaylistDrawer.module.css';
+
+interface FiltersState {
+  durMin: string;
+  durMax: string;
+  confMin: string;
+  qualMin: string;
+  audio: string;
+  subs: 'any' | 'yes' | 'no';
+  yearMin: string;
+  yearMax: string;
+  drive: string;
+  genres: string;
+  target: string;
+  mode: PlaylistOrderMode;
+  name: string;
+}
+
+const DEFAULT_FILTERS: FiltersState = {
+  durMin: '120',
+  durMax: '180',
+  confMin: '0.6',
+  qualMin: '60',
+  audio: '',
+  subs: 'any',
+  yearMin: '',
+  yearMax: '',
+  drive: '',
+  genres: '',
+  target: '150',
+  mode: 'weighted',
+  name: 'evening-playlist',
+};
+
+const STORAGE_KEY = 'videocatalog_evening_playlist';
+
+function parseNumber(value: string): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  if (Number.isNaN(parsed)) return undefined;
+  return parsed;
+}
+
+function formatMinutes(value?: number | null): string {
+  if (!value) return '—';
+  const hours = Math.floor(value / 60);
+  const minutes = value % 60;
+  if (hours <= 0) return `${minutes}m`;
+  if (minutes === 0) return `${hours}h`;
+  return `${hours}h ${minutes}m`;
+}
+
+function buildPlaylistParams(filters: FiltersState): Record<string, unknown> {
+  return {
+    dur_min: filters.durMin || undefined,
+    dur_max: filters.durMax || undefined,
+    conf_min: filters.confMin || undefined,
+    qual_min: filters.qualMin || undefined,
+    audio: filters.audio || undefined,
+    subs: filters.subs !== 'any' ? filters.subs : undefined,
+    year_min: filters.yearMin || undefined,
+    year_max: filters.yearMax || undefined,
+    drive: filters.drive || undefined,
+    genres: filters.genres || undefined,
+  };
+}
+
+function parseLanguages(value: string): string[] {
+  if (!value) return [];
+  return value
+    .split(',')
+    .map(part => part.trim())
+    .filter(Boolean);
+}
+
+function describeBadge(value: number, goodThreshold: number, warnThreshold: number): 'good' | 'warn' | 'critical' {
+  if (value >= goodThreshold) return 'good';
+  if (value >= warnThreshold) return 'warn';
+  return 'critical';
+}
+
+export function PlaylistDrawer() {
+  const { drawerOpen, closeDrawer, selectedItems, toggleSelected, clearSelection } = usePlaylist();
+  const [filters, setFilters] = useState<FiltersState>(DEFAULT_FILTERS);
+  const [suggestions, setSuggestions] = useState<PlaylistCandidateRow[]>([]);
+  const [playlist, setPlaylist] = useState<PlaylistBuildResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [exportMessage, setExportMessage] = useState<string | null>(null);
+  const [aiPlan, setAiPlan] = useState<PlaylistAiResponse | null>(null);
+  const [aiLoading, setAiLoading] = useState(false);
+  const [aiError, setAiError] = useState<string | null>(null);
+  const [restored, setRestored] = useState(false);
+  const { status: assistantStatus } = useAssistantStatus();
+
+  useEffect(() => {
+    if (!drawerOpen) return;
+    if (restored) return;
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored) as { filters?: Partial<FiltersState>; playlist?: PlaylistBuildResponse };
+        if (parsed.filters) {
+          setFilters(prev => ({ ...prev, ...parsed.filters }));
+        }
+        if (parsed.playlist) {
+          setPlaylist(parsed.playlist);
+        }
+      }
+    } catch (err) {
+      console.warn('Unable to restore saved playlist', err);
+    } finally {
+      setRestored(true);
+    }
+  }, [drawerOpen, restored]);
+
+  useEffect(() => {
+    if (!drawerOpen) {
+      setError(null);
+      setExportMessage(null);
+      setAiError(null);
+      setAiPlan(null);
+    }
+  }, [drawerOpen]);
+
+  const handleChange = (key: keyof FiltersState, value: string) => {
+    setFilters(prev => ({ ...prev, [key]: value }));
+  };
+
+  const handleGenerate = async (event?: FormEvent) => {
+    if (event) {
+      event.preventDefault();
+    }
+    setLoading(true);
+    setError(null);
+    setExportMessage(null);
+    try {
+      const params = buildPlaylistParams(filters);
+      const response = await getPlaylistSuggestions(params);
+      setSuggestions(response.candidates);
+      const ids = response.candidates.map(item => item.id);
+      if (ids.length === 0) {
+        setPlaylist({ mode: filters.mode, total_minutes: 0, items: [], target_minutes: parseNumber(filters.target) ?? null });
+        return;
+      }
+      const buildResponse = await buildPlaylist({
+        items: ids,
+        mode: filters.mode,
+        target_minutes: parseNumber(filters.target) ?? null,
+      });
+      setPlaylist(buildResponse);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleAddSelection = async () => {
+    if (selectedItems.length === 0) {
+      setError('Select at least one movie or episode to add.');
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const selectionIds = selectedItems.map(item => item.id);
+      const existingIds = playlist?.items.map(item => item.id) ?? [];
+      const merged = Array.from(new Set([...existingIds, ...selectionIds]));
+      const buildResponse = await buildPlaylist({
+        items: merged,
+        mode: filters.mode,
+        target_minutes: parseNumber(filters.target) ?? null,
+      });
+      setPlaylist(buildResponse);
+      setExportMessage(`Added ${selectionIds.length} item(s) from selection.`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSave = () => {
+    if (!playlist) {
+      setExportMessage('Generate a playlist before saving.');
+      return;
+    }
+    try {
+      const payload = JSON.stringify({ filters, playlist });
+      localStorage.setItem(STORAGE_KEY, payload);
+      setExportMessage('Playlist saved to browser storage.');
+    } catch (err) {
+      setError(`Unable to save playlist: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  };
+
+  const handleExport = async (format: 'm3u' | 'csv') => {
+    if (!playlist || playlist.items.length === 0) {
+      setError('Generate a playlist before exporting.');
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await exportPlaylist({
+        name: filters.name || 'evening-playlist',
+        format,
+        items: playlist.items.map(item => ({ path: item.path, title: item.title })),
+      });
+      setExportMessage(`Exported ${response.count} entries to ${response.path}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleOpenPlan = async (item: PlaylistBuildItemRow) => {
+    try {
+      const plan = await openPlaylistFolder(item.open_plan.path || item.path);
+      alert(`Execute plan: ${plan.plan} ${plan.path}`);
+    } catch (err) {
+      alert(`Unable to prepare open-folder plan: ${err instanceof Error ? err.message : err}`);
+    }
+  };
+
+  const handleAiAssist = async () => {
+    if (!assistantStatus?.enabled) return;
+    setAiLoading(true);
+    setAiError(null);
+    try {
+      const constraints: Record<string, unknown> = {
+        dur_min: parseNumber(filters.durMin),
+        dur_max: parseNumber(filters.durMax),
+        conf_min: parseNumber(filters.confMin),
+        qual_min: parseNumber(filters.qualMin),
+        langs_audio: parseLanguages(filters.audio),
+        genres: parseLanguages(filters.genres),
+        target_minutes: parseNumber(filters.target),
+      };
+      const plan = await requestPlaylistAi(`Evening playlist for ${filters.name}`, constraints);
+      setAiPlan(plan);
+      if (plan.items.length > 0) {
+        const buildResponse = await buildPlaylist({
+          items: plan.items.map(item => item.id),
+          mode: filters.mode,
+          target_minutes: parseNumber(filters.target) ?? null,
+        });
+        setPlaylist(buildResponse);
+        setExportMessage('Applied AI assisted ordering.');
+      }
+    } catch (err) {
+      setAiError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setAiLoading(false);
+    }
+  };
+
+  const hasAssistant = Boolean(assistantStatus?.enabled);
+
+  const drawerClass = clsx(styles.drawer, drawerOpen && styles.drawerVisible);
+  const overlayClass = clsx(styles.overlay, drawerOpen && styles.overlayVisible);
+
+  const selectionSummary = useMemo(() => {
+    if (selectedItems.length === 0) return 'No items selected.';
+    return `${selectedItems.length} selected`;
+  }, [selectedItems]);
+
+  return (
+    <div className={overlayClass} aria-hidden={!drawerOpen}>
+      <aside className={drawerClass} role="dialog" aria-modal="true" aria-label="Evening playlist composer">
+        <header className={styles.header}>
+          <h2>Evening Playlist</h2>
+          <button className={styles.closeButton} onClick={closeDrawer} aria-label="Close playlist drawer">
+            ×
+          </button>
+        </header>
+        <section className={styles.body}>
+          <form className={styles.filters} onSubmit={handleGenerate}>
+            <div className={styles.filterRow}>
+              <label>Target minutes</label>
+              <input
+                type="number"
+                min={0}
+                value={filters.target}
+                onChange={event => handleChange('target', event.target.value)}
+              />
+            </div>
+            <div className={styles.filterRow}>
+              <label>Duration window</label>
+              <div className={styles.inlineInputs}>
+                <input
+                  type="number"
+                  min={0}
+                  placeholder="min"
+                  value={filters.durMin}
+                  onChange={event => handleChange('durMin', event.target.value)}
+                />
+                <input
+                  type="number"
+                  min={0}
+                  placeholder="max"
+                  value={filters.durMax}
+                  onChange={event => handleChange('durMax', event.target.value)}
+                />
+              </div>
+            </div>
+            <div className={styles.filterRow}>
+              <label>Confidence ≥</label>
+              <input
+                type="number"
+                min={0}
+                max={1}
+                step={0.05}
+                value={filters.confMin}
+                onChange={event => handleChange('confMin', event.target.value)}
+              />
+            </div>
+            <div className={styles.filterRow}>
+              <label>Quality ≥</label>
+              <input
+                type="number"
+                min={0}
+                max={100}
+                value={filters.qualMin}
+                onChange={event => handleChange('qualMin', event.target.value)}
+              />
+            </div>
+            <div className={styles.filterRow}>
+              <label>Audio languages</label>
+              <input
+                type="text"
+                placeholder="e.g. en,fr"
+                value={filters.audio}
+                onChange={event => handleChange('audio', event.target.value)}
+              />
+            </div>
+            <div className={styles.filterRow}>
+              <label>Subtitle requirement</label>
+              <select value={filters.subs} onChange={event => handleChange('subs', event.target.value as FiltersState['subs'])}>
+                <option value="any">Any</option>
+                <option value="yes">Require subtitles</option>
+                <option value="no">No subtitles</option>
+              </select>
+            </div>
+            <div className={styles.filterRow}>
+              <label>Year range</label>
+              <div className={styles.inlineInputs}>
+                <input
+                  type="number"
+                  placeholder="from"
+                  value={filters.yearMin}
+                  onChange={event => handleChange('yearMin', event.target.value)}
+                />
+                <input
+                  type="number"
+                  placeholder="to"
+                  value={filters.yearMax}
+                  onChange={event => handleChange('yearMax', event.target.value)}
+                />
+              </div>
+            </div>
+            <div className={styles.filterRow}>
+              <label>Drive</label>
+              <input
+                type="text"
+                value={filters.drive}
+                onChange={event => handleChange('drive', event.target.value)}
+              />
+            </div>
+            <div className={styles.filterRow}>
+              <label>Genres</label>
+              <input
+                type="text"
+                placeholder="comma separated"
+                value={filters.genres}
+                onChange={event => handleChange('genres', event.target.value)}
+              />
+            </div>
+            <div className={styles.filterRow}>
+              <label>Sort mode</label>
+              <select value={filters.mode} onChange={event => handleChange('mode', event.target.value as PlaylistOrderMode)}>
+                <option value="weighted">Weighted shuffle</option>
+                <option value="sort_quality">Quality</option>
+                <option value="sort_confidence">Confidence</option>
+              </select>
+            </div>
+            <div className={styles.filterRow}>
+              <label>Export name</label>
+              <input
+                type="text"
+                value={filters.name}
+                onChange={event => handleChange('name', event.target.value)}
+              />
+            </div>
+            <div className={styles.actionsRow}>
+              <button type="submit" className={styles.primaryButton} disabled={loading}>
+                {loading ? 'Generating…' : 'Generate'}
+              </button>
+              <button type="button" onClick={handleAddSelection} className={styles.secondaryButton} disabled={loading}>
+                Add selection
+              </button>
+              <button type="button" onClick={handleSave} className={styles.secondaryButton}>
+                Save
+              </button>
+            </div>
+            <div className={styles.actionsRow}>
+              <button type="button" onClick={() => handleExport('m3u')} className={styles.secondaryButton} disabled={loading}>
+                Export M3U
+              </button>
+              <button type="button" onClick={() => handleExport('csv')} className={styles.secondaryButton} disabled={loading}>
+                Export CSV
+              </button>
+            </div>
+            {hasAssistant && (
+              <div className={styles.actionsRow}>
+                <button type="button" className={styles.secondaryButton} onClick={handleAiAssist} disabled={aiLoading}>
+                  {aiLoading ? 'Consulting AI…' : 'AI assist'}
+                </button>
+              </div>
+            )}
+          </form>
+          <aside className={styles.sidebar} aria-label="Selection summary">
+            <h3>Selection</h3>
+            <p className={styles.selectionSummary}>{selectionSummary}</p>
+            {selectedItems.length > 0 && (
+              <ul className={styles.selectionList}>
+                {selectedItems.map(item => (
+                  <li key={item.id}>
+                    <button type="button" onClick={() => toggleSelected(item)} className={styles.selectionItem}>
+                      <span>{item.title ?? item.id}</span>
+                      <span className={styles.selectionMeta}>
+                        {item.year ?? '—'} · {Math.round((item.confidence ?? 0) * 100)}%
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+            <button type="button" className={styles.linkButton} onClick={clearSelection} disabled={selectedItems.length === 0}>
+              Clear selection
+            </button>
+            {aiPlan && (
+              <div className={styles.aiPlanBox}>
+                <h4>AI summary</h4>
+                <p>{aiPlan.reasoning}</p>
+                {aiPlan.items.length > 0 && (
+                  <ul>
+                    {aiPlan.items.map(item => (
+                      <li key={item.id}>
+                        {item.id}
+                        {item.reason && <span className={styles.selectionMeta}> · {item.reason}</span>}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                {aiPlan.sources.length > 0 && <p className={styles.selectionMeta}>Sources: {aiPlan.sources.join(', ')}</p>}
+              </div>
+            )}
+          </aside>
+        </section>
+        <section className={styles.results} aria-label="Playlist results">
+          {error && <div className={styles.error}>{error}</div>}
+          {exportMessage && <div className={styles.notice}>{exportMessage}</div>}
+          {aiError && <div className={styles.error}>{aiError}</div>}
+          <div className={styles.sectionHeader}>
+            <h3>Playlist</h3>
+            {playlist && <span>{formatMinutes(playlist.total_minutes)}</span>}
+          </div>
+          {playlist && playlist.items.length === 0 && !loading && <p className={styles.placeholder}>No playlist generated yet.</p>}
+          {playlist && playlist.items.length > 0 && (
+            <ol className={styles.playlistList}>
+              {playlist.items.map(item => {
+                const qualityTone = item.quality != null ? describeBadge(item.quality, 75, 40) : null;
+                const confidenceTone = describeBadge(item.confidence * 100, 80, 55);
+                return (
+                  <li key={item.id} className={styles.playlistItem}>
+                    <div>
+                      <strong>{item.title ?? item.id}</strong>
+                      <div className={styles.playlistMeta}>
+                        <span>{item.year ?? '—'}</span>
+                        <span>{item.drive ?? '—'}</span>
+                        <span>{formatMinutes(item.duration_min ?? undefined)}</span>
+                        <span>{item.masked_path}</span>
+                      </div>
+                      <div className={styles.badges}>
+                        <span className={clsx(styles.badge, styles[`badge-${confidenceTone}`])}>
+                          {Math.round(item.confidence * 100)}% conf
+                        </span>
+                        {item.quality != null && (
+                          <span className={clsx(styles.badge, qualityTone && styles[`badge-${qualityTone}`])}>
+                            Quality {item.quality}
+                          </span>
+                        )}
+                      </div>
+                      <div className={styles.playlistMeta}>
+                        <span>Audio: {item.langs_audio.join(', ') || '—'}</span>
+                        <span>Subs: {item.langs_subs.join(', ') || (item.subs_present ? 'Yes' : '—')}</span>
+                      </div>
+                    </div>
+                    <button type="button" className={styles.linkButton} onClick={() => handleOpenPlan(item)}>
+                      Open folder
+                    </button>
+                  </li>
+                );
+              })}
+            </ol>
+          )}
+          <div className={styles.sectionHeader}>
+            <h3>Suggestions</h3>
+            <span>{suggestions.length} items</span>
+          </div>
+          {suggestions.length === 0 && !loading && <p className={styles.placeholder}>No suggestions available yet.</p>}
+          {suggestions.length > 0 && (
+            <ul className={styles.suggestionList}>
+              {suggestions.map(item => {
+                const tone = item.quality != null ? describeBadge(item.quality, 75, 40) : null;
+                return (
+                  <li key={item.id}>
+                    <div>
+                      <strong>{item.title ?? item.id}</strong>
+                      <div className={styles.playlistMeta}>
+                        <span>{item.year ?? '—'}</span>
+                        <span>{item.drive ?? '—'}</span>
+                        <span>{formatMinutes(item.duration_min ?? undefined)}</span>
+                        <span>{item.masked_path}</span>
+                      </div>
+                      <div className={styles.badges}>
+                        <span className={clsx(styles.badge, styles[`badge-${describeBadge(item.confidence * 100, 80, 55)}`])}>
+                          {Math.round(item.confidence * 100)}% conf
+                        </span>
+                        {item.quality != null && (
+                          <span className={clsx(styles.badge, tone && styles[`badge-${tone}`])}>Quality {item.quality}</span>
+                        )}
+                      </div>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </section>
+      </aside>
+    </div>
+  );
+}
+
+export default PlaylistDrawer;

--- a/web/catalog-ui/src/hooks/usePlaylist.tsx
+++ b/web/catalog-ui/src/hooks/usePlaylist.tsx
@@ -1,0 +1,88 @@
+import { createContext, ReactNode, useCallback, useContext, useMemo, useState } from 'react';
+
+export interface PlaylistSelectionItem {
+  id: string;
+  kind: 'movie' | 'episode' | string;
+  title?: string;
+  year?: number;
+  drive?: string | null;
+  quality?: number | null;
+  confidence?: number;
+}
+
+interface PlaylistContextValue {
+  drawerOpen: boolean;
+  openDrawer(): void;
+  closeDrawer(): void;
+  toggleSelected(item: PlaylistSelectionItem): void;
+  isSelected(id: string): boolean;
+  removeSelection(id: string): void;
+  clearSelection(): void;
+  selectedItems: PlaylistSelectionItem[];
+}
+
+const PlaylistContext = createContext<PlaylistContextValue | undefined>(undefined);
+
+export function PlaylistProvider({ children }: { children: ReactNode }) {
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [selected, setSelected] = useState<Map<string, PlaylistSelectionItem>>(new Map());
+
+  const openDrawer = useCallback(() => {
+    setDrawerOpen(true);
+  }, []);
+
+  const closeDrawer = useCallback(() => {
+    setDrawerOpen(false);
+  }, []);
+
+  const toggleSelected = useCallback((item: PlaylistSelectionItem) => {
+    setSelected(prev => {
+      const next = new Map(prev);
+      if (next.has(item.id)) {
+        next.delete(item.id);
+      } else {
+        next.set(item.id, item);
+      }
+      return next;
+    });
+  }, []);
+
+  const isSelected = useCallback((id: string) => selected.has(id), [selected]);
+
+  const removeSelection = useCallback((id: string) => {
+    setSelected(prev => {
+      if (!prev.has(id)) return prev;
+      const next = new Map(prev);
+      next.delete(id);
+      return next;
+    });
+  }, []);
+
+  const clearSelection = useCallback(() => {
+    setSelected(new Map());
+  }, []);
+
+  const value = useMemo<PlaylistContextValue>(
+    () => ({
+      drawerOpen,
+      openDrawer,
+      closeDrawer,
+      toggleSelected,
+      isSelected,
+      removeSelection,
+      clearSelection,
+      selectedItems: Array.from(selected.values()),
+    }),
+    [drawerOpen, openDrawer, closeDrawer, toggleSelected, isSelected, removeSelection, clearSelection, selected],
+  );
+
+  return <PlaylistContext.Provider value={value}>{children}</PlaylistContext.Provider>;
+}
+
+export function usePlaylist(): PlaylistContextValue {
+  const ctx = useContext(PlaylistContext);
+  if (!ctx) {
+    throw new Error('usePlaylist must be used within a PlaylistProvider');
+  }
+  return ctx;
+}

--- a/web/catalog-ui/src/pages/App.tsx
+++ b/web/catalog-ui/src/pages/App.tsx
@@ -2,12 +2,15 @@ import { Route, Routes } from 'react-router-dom';
 
 import AppShell from '../components/AppShell';
 import { DetailDrawer } from '../components/DetailDrawer';
+import { PlaylistDrawer } from '../components/PlaylistDrawer';
 import { useApiKey } from '../hooks/useApiKey';
 import { DetailDrawerProvider, useDetailDrawer } from '../hooks/useDetailDrawer';
 import { AssistantStatusProvider } from '../hooks/useAssistantStatus';
 import { LiveCatalogProvider } from '../hooks/useLiveCatalog';
+import { PlaylistProvider } from '../hooks/usePlaylist';
 import HomePage from './HomePage';
 import MoviesPage from './MoviesPage';
+import PlaylistPage from './PlaylistPage';
 import SearchPage from './SearchPage';
 import TvPage from './TvPage';
 import styles from './App.module.css';
@@ -44,8 +47,10 @@ function AppRoutes() {
         <Route path="/movies" element={<MoviesPage />} />
         <Route path="/tv" element={<TvPage />} />
         <Route path="/search" element={<SearchPage />} />
+        <Route path="/playlist" element={<PlaylistPage />} />
       </Routes>
       <DetailDrawer state={drawer.state} onClose={drawer.closeDetail} />
+      <PlaylistDrawer />
     </>
   );
 }
@@ -56,9 +61,11 @@ function InnerApp() {
     <AssistantStatusProvider>
       <LiveCatalogProvider>
         <DetailDrawerProvider>
-          <AppShell rightPanel={<ApiKeyBadge apiKey={apiKey} onUpdate={setApiKey} />}>
-            <AppRoutes />
-          </AppShell>
+          <PlaylistProvider>
+            <AppShell rightPanel={<ApiKeyBadge apiKey={apiKey} onUpdate={setApiKey} />}>
+              <AppRoutes />
+            </AppShell>
+          </PlaylistProvider>
         </DetailDrawerProvider>
       </LiveCatalogProvider>
     </AssistantStatusProvider>

--- a/web/catalog-ui/src/pages/MoviesPage.module.css
+++ b/web/catalog-ui/src/pages/MoviesPage.module.css
@@ -69,6 +69,28 @@
   gap: 1rem;
 }
 
+.playlistBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  color: rgba(226, 232, 240, 0.82);
+  font-size: 0.9rem;
+}
+
+.playlistButton {
+  border: none;
+  background: rgba(56, 189, 248, 0.2);
+  color: #0ea5e9;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
 .grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
@@ -80,6 +102,12 @@
   border-radius: 18px;
   overflow: hidden;
   border: 1px solid rgba(255, 255, 255, 0.06);
+  position: relative;
+}
+
+.cardSelected {
+  border-color: rgba(56, 189, 248, 0.6);
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.25);
 }
 
 .cardButton {
@@ -113,6 +141,51 @@
 .posterFallback {
   font-size: 0.85rem;
   color: rgba(255, 255, 255, 0.6);
+}
+
+.cardSelect {
+  position: absolute;
+  top: 0.65rem;
+  left: 0.65rem;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+}
+
+.cardSelect input {
+  appearance: none;
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  cursor: pointer;
+}
+
+.cardSelectVisual {
+  width: 20px;
+  height: 20px;
+  border-radius: 6px;
+  border: 2px solid rgba(226, 232, 240, 0.65);
+  background: rgba(15, 23, 42, 0.85);
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.cardSelected .cardSelectVisual {
+  background: #38bdf8;
+  border-color: #38bdf8;
+}
+
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .cardBody {

--- a/web/catalog-ui/src/pages/PlaylistPage.module.css
+++ b/web/catalog-ui/src/pages/PlaylistPage.module.css
@@ -1,0 +1,65 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 2rem clamp(1rem, 4vw, 3rem);
+  color: #f8fafc;
+}
+
+.hero {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.25), rgba(59, 130, 246, 0));
+  border-radius: 24px;
+  padding: 2rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.hero h1 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+}
+
+.hero p {
+  margin: 0 0 1.5rem;
+  line-height: 1.6;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.primaryButton {
+  padding: 0.8rem 1.6rem;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  background: linear-gradient(135deg, #38bdf8, #818cf8);
+  color: #0f172a;
+  cursor: pointer;
+}
+
+.panel {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 20px;
+  padding: 1.5rem;
+}
+
+.panel h2 {
+  margin: 0 0 0.75rem;
+}
+
+.panel p {
+  margin: 0;
+  line-height: 1.5;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.hint {
+  margin-top: 0.75rem;
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+@media (max-width: 720px) {
+  .hero,
+  .panel {
+    padding: 1.5rem;
+  }
+}

--- a/web/catalog-ui/src/pages/PlaylistPage.tsx
+++ b/web/catalog-ui/src/pages/PlaylistPage.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { usePlaylist } from '../hooks/usePlaylist';
+import styles from './PlaylistPage.module.css';
+
+interface SavedSnapshot {
+  filters?: { target?: string };
+  playlist?: { total_minutes?: number; items?: Array<{ id: string; title?: string }> };
+}
+
+const STORAGE_KEY = 'videocatalog_evening_playlist';
+
+export default function PlaylistPage() {
+  const { openDrawer, selectedItems } = usePlaylist();
+  const [saved, setSaved] = useState<SavedSnapshot | null>(null);
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) {
+        setSaved(JSON.parse(raw) as SavedSnapshot);
+      }
+    } catch (err) {
+      console.warn('Unable to parse saved playlist', err);
+    }
+  }, []);
+
+  const selectionSummary = useMemo(() => {
+    if (selectedItems.length === 0) return 'No items currently selected in the catalog.';
+    return `${selectedItems.length} item(s) selected — ready to add to tonight's queue.`;
+  }, [selectedItems]);
+
+  const savedSummary = useMemo(() => {
+    if (!saved?.playlist || !saved.playlist.items || saved.playlist.items.length === 0) {
+      return 'No saved playlist yet. Use the drawer to generate and save a plan for tonight.';
+    }
+    const names = saved.playlist.items.slice(0, 3).map(item => item.title ?? item.id);
+    const ellipsis = saved.playlist.items.length > 3 ? '…' : '';
+    const total = saved.playlist.total_minutes ? `${saved.playlist.total_minutes} minutes planned.` : '';
+    return `${names.join(', ')}${ellipsis} ${total}`.trim();
+  }, [saved]);
+
+  return (
+    <div className={styles.container}>
+      <section className={styles.hero}>
+        <h1>Evening Playlist</h1>
+        <p>
+          Compose a quick movie or TV marathon for tonight without touching your media library. Generate suggestions, mix in
+          favourites, and export an M3U or CSV playlist directly under <code>working_dir/exports/playlists/</code>.
+        </p>
+        <button className={styles.primaryButton} onClick={openDrawer}>
+          Open playlist composer
+        </button>
+      </section>
+      <section className={styles.panel}>
+        <h2>Current selection</h2>
+        <p>{selectionSummary}</p>
+      </section>
+      <section className={styles.panel}>
+        <h2>Last saved playlist</h2>
+        <p>{savedSummary}</p>
+        <p className={styles.hint}>Saving happens locally in your browser — export to persist on disk.</p>
+      </section>
+    </div>
+  );
+}

--- a/web/catalog-ui/src/pages/TvPage.module.css
+++ b/web/catalog-ui/src/pages/TvPage.module.css
@@ -78,6 +78,29 @@
   padding: 1.5rem 1.75rem;
 }
 
+.playlistBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.6rem 0.85rem;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  color: rgba(226, 232, 240, 0.8);
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+}
+
+.playlistButton {
+  border: none;
+  background: rgba(56, 189, 248, 0.2);
+  color: #0ea5e9;
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
 .seriesHeader {
   display: flex;
   justify-content: space-between;
@@ -117,6 +140,12 @@
   border-radius: 16px;
   overflow: hidden;
   border: 1px solid rgba(255, 255, 255, 0.06);
+  position: relative;
+}
+
+.episodeCardSelected {
+  border-color: rgba(56, 189, 248, 0.6);
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.25);
 }
 
 .episodeCard button {
@@ -147,6 +176,51 @@
 
 .posterFallback {
   color: rgba(255, 255, 255, 0.65);
+}
+
+.episodeSelect {
+  position: absolute;
+  top: 0.6rem;
+  left: 0.6rem;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+}
+
+.episodeSelect input {
+  appearance: none;
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  cursor: pointer;
+}
+
+.episodeSelectVisual {
+  width: 20px;
+  height: 20px;
+  border-radius: 6px;
+  border: 2px solid rgba(226, 232, 240, 0.65);
+  background: rgba(15, 23, 42, 0.85);
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.episodeCardSelected .episodeSelectVisual {
+  background: #38bdf8;
+  border-color: #38bdf8;
+}
+
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .episodeBody {


### PR DESCRIPTION
## Summary
- add catalog playlist queries, export helper, and FastAPI endpoints for suggest/build/export/open-folder/ai
- implement a reusable playlist provider plus drawer UI with filters, exports, and optional AI assist
- expose an Evening Playlist page and selection controls on movies and TV grids that feed the drawer

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68eaa29c57c0832796ec88b2f81ee2b8