### PR TITLE
Add Windows launcher and localhost defaults

### DIFF
--- a/DiskScannerGUI.py
+++ b/DiskScannerGUI.py
@@ -225,15 +225,15 @@ if isinstance(_api_settings, dict):
     API_ENABLED_DEFAULT = bool(_api_settings.get("enabled_default", False))
     API_HOST_DEFAULT = str(_api_settings.get("host") or "127.0.0.1")
     try:
-        API_PORT_DEFAULT = int(_api_settings.get("port") or 8756)
+        API_PORT_DEFAULT = int(_api_settings.get("port") or 27182)
     except (TypeError, ValueError):
-        API_PORT_DEFAULT = 8756
+        API_PORT_DEFAULT = 27182
     API_KEY_PRESENT_DEFAULT = bool(str(_api_settings.get("api_key") or "").strip())
     API_KEY_VALUE_DEFAULT = str(_api_settings.get("api_key") or "").strip()
 else:
     API_ENABLED_DEFAULT = False
     API_HOST_DEFAULT = "127.0.0.1"
-    API_PORT_DEFAULT = 8756
+    API_PORT_DEFAULT = 27182
     API_KEY_PRESENT_DEFAULT = False
     API_KEY_VALUE_DEFAULT = ""
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -139,7 +139,7 @@ DEFAULT_SETTINGS: Dict[str, Any] = {
     "api": {
         "enabled_default": False,
         "host": "127.0.0.1",
-        "port": 8756,
+        "port": 27182,
         "api_key": None,
         "cors_origins": ["http://localhost", "http://127.0.0.1"],
         "default_limit": 100,

--- a/diskscannergui.py
+++ b/diskscannergui.py
@@ -1,0 +1,47 @@
+"""Compatibility shim launching the VideoCatalog A2.0 web UI."""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _find_launcher() -> tuple[list[str], str]:
+    root = Path(__file__).resolve().parent
+    scripts_dir = root / "scripts"
+    ps1 = scripts_dir / "start_videocatalog.ps1"
+    bat = scripts_dir / "start_videocatalog.bat"
+
+    for candidate in ("powershell.exe", "powershell", "pwsh.exe", "pwsh"):
+        resolved = shutil.which(candidate)
+        if resolved and ps1.exists():
+            return ([resolved, "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", str(ps1)], "powershell")
+    if os.name == "nt" and bat.exists():
+        return (["cmd.exe", "/c", str(bat)], "batch")
+    if bat.exists():
+        return ([str(bat)], "batch")
+    raise FileNotFoundError("Unable to locate VideoCatalog launcher scripts.")
+
+
+def main() -> int:
+    print("VideoCatalog A2.0: launching local Web UI…", flush=True)
+    try:
+        command, kind = _find_launcher()
+    except FileNotFoundError as exc:
+        print(f"Launcher error: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        result = subprocess.run(command, check=False)
+    except FileNotFoundError as exc:
+        print(f"Failed to start {kind} launcher: {exc}", file=sys.stderr)
+        return 3
+    except KeyboardInterrupt:
+        return 130
+    return int(result.returncode)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/create_shortcut.ps1
+++ b/scripts/create_shortcut.ps1
@@ -1,0 +1,33 @@
+param(
+    [string]$Name = 'VideoCatalog (A2.0)'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$projectRoot = Resolve-Path (Join-Path $scriptRoot '..')
+$desktop = [Environment]::GetFolderPath('Desktop')
+if (-not $desktop) {
+    Write-Error 'Unable to resolve the Desktop folder for the current user.'
+    exit 2
+}
+
+$target = Join-Path $projectRoot 'scripts/start_videocatalog.bat'
+if (-not (Test-Path $target)) {
+    Write-Error "Launcher not found at $target"
+    exit 3
+}
+
+$shortcutPath = Join-Path $desktop ($Name + '.lnk')
+$wsh = New-Object -ComObject WScript.Shell
+$shortcut = $wsh.CreateShortcut($shortcutPath)
+$shortcut.TargetPath = $target
+$shortcut.WorkingDirectory = $projectRoot
+$iconCandidate = Join-Path $projectRoot 'web/icon.ico'
+if (Test-Path $iconCandidate) {
+    $shortcut.IconLocation = $iconCandidate
+}
+$shortcut.Save()
+
+Write-Host "Created shortcut at $shortcutPath" -ForegroundColor Cyan

--- a/scripts/start_videocatalog.bat
+++ b/scripts/start_videocatalog.bat
@@ -1,0 +1,18 @@
+@echo off
+setlocal
+set SCRIPT_DIR=%~dp0
+
+for %%P in (powershell.exe powershell pwsh.exe pwsh) do (
+    where %%P >nul 2>nul
+    if not errorlevel 1 (
+        set PS_BIN=%%P
+        goto :found
+    )
+)
+echo PowerShell not found. Please install PowerShell 5 or newer.
+endlocal & exit /b 1
+
+:found
+"%PS_BIN%" -NoProfile -ExecutionPolicy Bypass -File "%SCRIPT_DIR%start_videocatalog.ps1" %*
+set EXITCODE=%ERRORLEVEL%
+endlocal & exit /b %EXITCODE%

--- a/scripts/start_videocatalog.ps1
+++ b/scripts/start_videocatalog.ps1
@@ -1,0 +1,363 @@
+param(
+    [switch]$NoBrowser
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Write-Info {
+    param([string]$Message)
+    Write-Host $Message -ForegroundColor Cyan
+}
+
+function Write-Warn {
+    param([string]$Message)
+    Write-Host $Message -ForegroundColor Yellow
+}
+
+function Write-Err {
+    param([string]$Message)
+    Write-Host $Message -ForegroundColor Red
+}
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$projectRoot = Resolve-Path (Join-Path $scriptRoot '..')
+Set-Location $projectRoot
+
+Write-Info "VideoCatalog A2.0 launcher"
+
+if (-not $env:USERPROFILE) {
+    Write-Err "USERPROFILE environment variable is not set."
+    exit 2
+}
+
+$workingDir = Join-Path $env:USERPROFILE 'VideoCatalog'
+$directories = @(
+    $workingDir,
+    (Join-Path $workingDir 'data'),
+    (Join-Path $workingDir 'logs'),
+    (Join-Path $workingDir 'exports'),
+    (Join-Path $workingDir 'backups'),
+    (Join-Path $workingDir 'vectors')
+)
+foreach ($dir in $directories) {
+    if (-not (Test-Path $dir)) {
+        New-Item -ItemType Directory -Path $dir | Out-Null
+    }
+}
+
+$settingsSource = Join-Path $projectRoot 'settings.json'
+$userSettingsPath = Join-Path $workingDir 'settings.json'
+if (-not (Test-Path $userSettingsPath)) {
+    if (Test-Path $settingsSource) {
+        Copy-Item -Path $settingsSource -Destination $userSettingsPath -Force
+    } else {
+        '{}' | Set-Content -Path $userSettingsPath -Encoding UTF8
+    }
+}
+
+try {
+    $settingsRaw = Get-Content -Path $userSettingsPath -Raw -Encoding UTF8
+} catch {
+    $settingsRaw = '{}'
+}
+
+try {
+    $settings = $settingsRaw | ConvertFrom-Json
+} catch {
+    Write-Warn "settings.json is invalid JSON. Recreating defaults."
+    $settings = New-Object PSObject
+}
+
+if (-not ($settings | Get-Member -Name 'server' -ErrorAction SilentlyContinue)) {
+    $settings | Add-Member -NotePropertyName 'server' -NotePropertyValue ([pscustomobject]@{})
+}
+$serverSettings = $settings.server
+if ($null -eq $serverSettings -or -not ($serverSettings -is [psobject])) {
+    $serverSettings = [pscustomobject]@{}
+    $settings.server = $serverSettings
+}
+$serverSettings.host = '127.0.0.1'
+$serverSettings.port = 27182
+$serverSettings.lan_refuse = $true
+
+if (-not ($settings | Get-Member -Name 'catalog_db' -ErrorAction SilentlyContinue)) {
+    $settings | Add-Member -NotePropertyName 'catalog_db' -NotePropertyValue ''
+}
+$catalogDbPath = Join-Path $workingDir 'catalog.db'
+$targetCatalog = [System.IO.Path]::GetFullPath($catalogDbPath)
+$needsCatalogUpdate = $true
+$existingCatalog = [string]$settings.catalog_db
+if (-not [string]::IsNullOrWhiteSpace($existingCatalog)) {
+    $expandedCatalog = [Environment]::ExpandEnvironmentVariables($existingCatalog)
+    try {
+        $resolvedExisting = [System.IO.Path]::GetFullPath($expandedCatalog)
+    } catch {
+        $resolvedExisting = $expandedCatalog
+    }
+    if ($resolvedExisting.Trim().ToLowerInvariant() -eq $targetCatalog.Trim().ToLowerInvariant()) {
+        $needsCatalogUpdate = $false
+    }
+}
+if ($needsCatalogUpdate) {
+    $settings.catalog_db = $targetCatalog
+}
+
+if (-not ($settings | Get-Member -Name 'working_dir' -ErrorAction SilentlyContinue)) {
+    $settings | Add-Member -NotePropertyName 'working_dir' -NotePropertyValue $workingDir
+} else {
+    $settings.working_dir = $workingDir
+}
+
+$updatedJson = $settings | ConvertTo-Json -Depth 100
+[System.IO.File]::WriteAllText($userSettingsPath, $updatedJson + [Environment]::NewLine, [System.Text.Encoding]::UTF8)
+
+foreach ($suffix in @('catalog.db-wal', 'catalog.db-shm')) {
+    $path = Join-Path $projectRoot $suffix
+    if (Test-Path $path) {
+        Remove-Item -Path $path -Force -ErrorAction SilentlyContinue
+    }
+}
+
+$pythonCmd = Get-Command python -ErrorAction SilentlyContinue
+if (-not $pythonCmd) {
+    Write-Err 'Python executable not found on PATH.'
+    exit 3
+}
+$pythonExe = $pythonCmd.Source
+if (-not $pythonExe) { $pythonExe = $pythonCmd.Path }
+if (-not $pythonExe) { $pythonExe = $pythonCmd.Definition }
+
+$pipCmd = Get-Command pip -ErrorAction SilentlyContinue
+if ($pipCmd) {
+    $pipExe = $pipCmd.Source
+    if (-not $pipExe) { $pipExe = $pipCmd.Path }
+    if (-not $pipExe) { $pipExe = $pipCmd.Definition }
+} else {
+    Write-Warn 'pip executable not found on PATH. Falling back to python -m pip.'
+    $pipExe = $null
+}
+
+$env:VIDEOCATALOG_HOME = $workingDir
+
+$uvicornCheck = & $pythonExe -c "import uvicorn" 2>$null
+if ($LASTEXITCODE -ne 0) {
+    $requirementsPath = Join-Path $projectRoot 'requirements-windows.txt'
+    if (-not (Test-Path $requirementsPath)) {
+        $requirementsPath = Join-Path $projectRoot 'requirements.txt'
+    }
+    Write-Info "Installing Python dependencies from $requirementsPath"
+    if ($pipExe) {
+        & $pipExe install -r $requirementsPath
+        if ($LASTEXITCODE -ne 0) {
+            Write-Err 'pip install failed.'
+            exit 4
+        }
+    } else {
+        & $pythonExe -m pip install -r $requirementsPath
+        if ($LASTEXITCODE -ne 0) {
+            Write-Err 'python -m pip install failed.'
+            exit 4
+        }
+    }
+}
+
+if (-not (Get-Command ffprobe -ErrorAction SilentlyContinue)) {
+    Write-Warn 'ffprobe not found on PATH. Quality headers will be disabled until installed.'
+}
+
+$tempProbe = [System.IO.Path]::GetTempFileName()
+$probeScript = @"
+from pathlib import Path
+import json
+from orchestrator.gpu import GPUManager
+from orchestrator.logs import OrchestratorLogger
+from core.settings import load_settings
+from core.paths import ensure_working_dir_structure
+
+working_dir = Path(r'$workingDir')
+ensure_working_dir_structure(working_dir)
+settings = load_settings(working_dir)
+orch_cfg = dict(settings.get('orchestrator', {}))
+gpu_cfg = dict(settings.get('gpu', {}))
+manager = GPUManager(
+    logger=OrchestratorLogger(working_dir),
+    safety_margin_mb=int(orch_cfg.get('gpu', {}).get('safety_margin_mb', 1024) if isinstance(orch_cfg.get('gpu'), dict) else 1024),
+    lease_ttl_s=int(orch_cfg.get('lease_ttl_s', 120)),
+)
+required = int(gpu_cfg.get('min_free_vram_mb', 512))
+result = manager.preflight(required)
+info = result.info
+payload = {
+    'ok': bool(result.ok),
+    'present': bool(info.present),
+    'name': info.name,
+    'free_mb': int(getattr(info, 'vram_free_mb', 0) or 0),
+    'total_mb': int(getattr(info, 'vram_total_mb', 0) or 0),
+    'reason': result.reason or info.error,
+}
+print(json.dumps(payload))
+"@
+[System.IO.File]::WriteAllText($tempProbe, $probeScript, [System.Text.Encoding]::UTF8)
+$gpuProbeOutput = & $pythonExe $tempProbe
+$gpuStatus = $null
+if ($LASTEXITCODE -eq 0 -and $gpuProbeOutput) {
+    try {
+        $gpuStatus = $gpuProbeOutput | ConvertFrom-Json
+    } catch {
+        $gpuStatus = $null
+    }
+}
+Remove-Item -Path $tempProbe -Force -ErrorAction SilentlyContinue
+
+if ($gpuStatus -and $gpuStatus.ok) {
+    $gpuSummary = "ready ($($gpuStatus.name) - free $($gpuStatus.free_mb) MB of $($gpuStatus.total_mb) MB)"
+} elseif ($gpuStatus -and $gpuStatus.present) {
+    $gpuSummary = "not-ready (GPU present but gated: $($gpuStatus.reason))"
+} elseif ($gpuStatus) {
+    $gpuSummary = "not-ready ($($gpuStatus.reason))"
+} else {
+    $gpuSummary = 'not-ready (probe failed)'
+}
+
+Write-Info "GPU status: $gpuSummary"
+
+function New-Process {
+    param(
+        [string]$FilePath,
+        [string[]]$Arguments,
+        [string]$Name,
+        [System.Collections.Generic.Dictionary[string, object]]$Handlers,
+        [System.Threading.ManualResetEvent]$ReadyEvent = $null,
+        [string[]]$ReadyPatterns = $null
+    )
+
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = $FilePath
+    $psi.Arguments = ($Arguments | ForEach-Object {
+        if ($_ -match '[\s\"]') {
+            '"' + ($_ -replace '"', '\"') + '"'
+        } else {
+            $_
+        }
+    }) -join ' '
+    $psi.WorkingDirectory = $projectRoot
+    $psi.UseShellExecute = $false
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    $psi.CreateNoWindow = $true
+    $psi.EnvironmentVariables['VIDEOCATALOG_HOME'] = $workingDir
+    $psi.EnvironmentVariables['PYTHONUNBUFFERED'] = '1'
+
+    $process = New-Object System.Diagnostics.Process
+    $process.StartInfo = $psi
+    $process.EnableRaisingEvents = $true
+    if (-not $process.Start()) {
+        throw "Failed to start $Name process."
+    }
+
+    $stdoutHandler = [System.Diagnostics.DataReceivedEventHandler]{
+        param($sender, $args)
+        if ([string]::IsNullOrWhiteSpace($args.Data)) { return }
+        Write-Host "[$Name] $($args.Data)"
+        if ($ReadyEvent -and $ReadyPatterns) {
+            foreach ($pattern in $ReadyPatterns) {
+                if ($args.Data -like $pattern) {
+                    $ReadyEvent.Set() | Out-Null
+                    break
+                }
+            }
+        }
+    }
+    $stderrHandler = [System.Diagnostics.DataReceivedEventHandler]{
+        param($sender, $args)
+        if ([string]::IsNullOrWhiteSpace($args.Data)) { return }
+        Write-Host "[$Name] $($args.Data)" -ForegroundColor DarkYellow
+    }
+
+    $process.add_OutputDataReceived($stdoutHandler)
+    $process.add_ErrorDataReceived($stderrHandler)
+    $process.BeginOutputReadLine()
+    $process.BeginErrorReadLine()
+
+    $Handlers[$Name] = @{ Output = $stdoutHandler; Error = $stderrHandler; Process = $process }
+    return $process
+}
+
+$handlers = New-Object 'System.Collections.Generic.Dictionary[string, object]'
+$orchReady = New-Object System.Threading.ManualResetEvent($false)
+$orchProcess = New-Process -FilePath $pythonExe -Arguments @('-m', 'orchestrator.scheduler', '--working-dir', $workingDir) -Name 'orchestrator' -Handlers $handlers -ReadyEvent $orchReady -ReadyPatterns @('ORCH_HEARTBEAT ready*')
+
+if (-not $orchReady.WaitOne(20000)) {
+    if ($orchProcess.HasExited) {
+        Write-Err "Orchestrator exited early with code $($orchProcess.ExitCode)."
+    } else {
+        Write-Err 'Orchestrator failed to report ready within 20 seconds.'
+        $orchProcess.Kill()
+    }
+    exit 5
+}
+
+Write-Info "Orchestrator running (PID $($orchProcess.Id))"
+
+$webReady = New-Object System.Threading.ManualResetEvent($false)
+$webProcess = New-Process -FilePath $pythonExe -Arguments @('-m', 'videocatalog_api', '--host', '127.0.0.1', '--port', '27182') -Name 'web' -Handlers $handlers -ReadyEvent $webReady -ReadyPatterns @('*Application startup complete*', '*Uvicorn running on http://127.0.0.1:27182*', '*API listening on http://127.0.0.1:27182*')
+
+if (-not $webReady.WaitOne(25000)) {
+    if ($webProcess.HasExited) {
+        Write-Err "Web server exited early with code $($webProcess.ExitCode)."
+    } else {
+        Write-Err 'Web server failed to start within 25 seconds.'
+        $webProcess.Kill()
+    }
+    if (-not $orchProcess.HasExited) { $orchProcess.Kill() }
+    exit 6
+}
+
+Write-Info "Web UI available at http://127.0.0.1:27182"
+
+if (-not $NoBrowser) {
+    try {
+        Start-Process 'http://127.0.0.1:27182' | Out-Null
+    } catch {
+        Write-Warn 'Failed to launch browser automatically.'
+    }
+}
+
+Write-Host ''
+Write-Info 'Summary:'
+Write-Host "  GPU: $gpuSummary"
+Write-Host "  Orchestrator: running (PID $($orchProcess.Id))"
+Write-Host '  Web: http://127.0.0.1:27182 (WS/SSE enabled)'
+Write-Host ''
+Write-Host 'Press Ctrl+C to stop both services.'
+
+$exitCode = 0
+try {
+    while ($true) {
+        if ($orchProcess.HasExited) {
+            $exitCode = $orchProcess.ExitCode
+            Write-Err "Orchestrator exited with code $exitCode"
+            break
+        }
+        if ($webProcess.HasExited) {
+            $exitCode = $webProcess.ExitCode
+            Write-Err "Web server exited with code $exitCode"
+            break
+        }
+        Start-Sleep -Seconds 1
+    }
+} finally {
+    foreach ($entry in $handlers.Values) {
+        $proc = $entry['Process']
+        if ($proc -and -not $proc.HasExited) {
+            try { $proc.Kill() } catch {}
+        }
+        $outputHandler = $entry['Output']
+        if ($proc) { $proc.remove_OutputDataReceived($outputHandler) }
+        $errorHandler = $entry['Error']
+        if ($proc) { $proc.remove_ErrorDataReceived($errorHandler) }
+    }
+}
+
+exit $exitCode

--- a/settings.json
+++ b/settings.json
@@ -105,7 +105,7 @@
   "api": {
     "enabled_default": false,
     "host": "127.0.0.1",
-    "port": 8756,
+    "port": 27182,
     "api_key": "localdev",
     "cors_origins": [
       "http://localhost",
@@ -116,7 +116,7 @@
   },
   "server": {
     "host": "127.0.0.1",
-    "port": 8756,
+    "port": 27182,
     "lan_refuse": true
   },
   "apiguard": {

--- a/stabilize.ps1
+++ b/stabilize.ps1
@@ -213,7 +213,7 @@ try {
     while ((Get-Date) -lt $deadline) {
         try {
             $headers = @{ 'X-API-Key' = $env:VIDEOCATALOG_API_KEY }
-            $response = Invoke-WebRequest -Uri 'http://127.0.0.1:8756/v1/health' -Headers $headers -TimeoutSec 5 -ErrorAction Stop
+            $response = Invoke-WebRequest -Uri 'http://127.0.0.1:27182/v1/health' -Headers $headers -TimeoutSec 5 -ErrorAction Stop
             if ($response.StatusCode -eq 200) {
                 $healthOk = $true
                 break
@@ -226,7 +226,7 @@ try {
         Add-Summary 'API server' 'FAIL' 'Server did not become ready'
         throw "API server failed to start"
     }
-    Add-Summary 'API server' 'PASS' 'API reachable on http://127.0.0.1:8756'
+    Add-Summary 'API server' 'PASS' 'API reachable on http://127.0.0.1:27182'
 
     # Optional orchestrator warmup when GPU present
     if ($gpuReady) {
@@ -387,7 +387,7 @@ finally:
     Write-Step "7) Assistant sanity check"
     try {
         $headers = @{ 'X-API-Key' = $env:VIDEOCATALOG_API_KEY }
-        $assistantStatus = Invoke-WebRequest -Uri 'http://127.0.0.1:8756/v1/assistant/status' -Headers $headers -TimeoutSec 10
+        $assistantStatus = Invoke-WebRequest -Uri 'http://127.0.0.1:27182/v1/assistant/status' -Headers $headers -TimeoutSec 10
         if ($assistantStatus.StatusCode -eq 200) {
             Add-Summary 'Assistant status' 'PASS' 'assistant/status reachable'
         } else {

--- a/videocatalog_api.py
+++ b/videocatalog_api.py
@@ -17,7 +17,7 @@ from core.paths import resolve_working_dir
 from core.settings import load_settings
 
 DEFAULT_HOST = "127.0.0.1"
-DEFAULT_PORT = 8756
+DEFAULT_PORT = 27182
 DEFAULT_CORS = ["http://localhost", "http://127.0.0.1"]
 
 

--- a/web_preflight.py
+++ b/web_preflight.py
@@ -13,7 +13,7 @@ import requests
 from core.paths import get_catalog_db_path, resolve_working_dir
 from core.settings import load_settings
 
-DEFAULT_BASE_URL = "http://127.0.0.1:8756"
+DEFAULT_BASE_URL = "http://127.0.0.1:27182"
 
 
 def _resolve_api_key(override: str | None, settings: Dict[str, object]) -> str | None:
@@ -162,9 +162,9 @@ def main(argv: List[str] | None = None) -> int:
     api_settings = settings.get("api") if isinstance(settings.get("api"), dict) else {}
     if isinstance(api_settings, dict):
         host = api_settings.get("host") or "127.0.0.1"
-        port = api_settings.get("port") or 8756
+        port = api_settings.get("port") or 27182
     else:
-        host, port = "127.0.0.1", 8756
+        host, port = "127.0.0.1", 27182
     base_default = args.api_base or f"http://{host}:{port}"
     api_base = args.api_base or base_default or DEFAULT_BASE_URL
     api_key = _resolve_api_key(args.api_key, settings)

--- a/web_smoke.py
+++ b/web_smoke.py
@@ -21,7 +21,7 @@ import requests
 from core.paths import get_catalog_db_path, resolve_working_dir
 from core.settings import load_settings
 
-DEFAULT_BASE_URL = "http://127.0.0.1:8756"
+DEFAULT_BASE_URL = "http://127.0.0.1:27182"
 
 
 def _resolve_api_key(override: Optional[str], settings: Dict[str, object]) -> Optional[str]:
@@ -301,9 +301,9 @@ def main(argv: Optional[List[str]] = None) -> int:
     api_settings = settings.get("api") if isinstance(settings.get("api"), dict) else {}
     if isinstance(api_settings, dict):
         host = api_settings.get("host") or "127.0.0.1"
-        port = api_settings.get("port") or 8756
+        port = api_settings.get("port") or 27182
     else:
-        host, port = "127.0.0.1", 8756
+        host, port = "127.0.0.1", 27182
     base_default = args.api_base or f"http://{host}:{port}"
     api_base = args.api_base or base_default or DEFAULT_BASE_URL
     api_key = _resolve_api_key(args.api_key, settings)

--- a/web_tools.py
+++ b/web_tools.py
@@ -41,9 +41,9 @@ def main(argv: list[str] | None = None) -> int:
     api_settings = settings.get("api") if isinstance(settings.get("api"), dict) else {}
     if isinstance(api_settings, dict):
         host = api_settings.get("host") or "127.0.0.1"
-        port = api_settings.get("port") or 8756
+        port = api_settings.get("port") or 27182
     else:
-        host, port = "127.0.0.1", 8756
+        host, port = "127.0.0.1", 27182
     base_default = args.api_base or f"http://{host}:{port}"
     api_base = (args.api_base or base_default or DEFAULT_BASE_URL).rstrip("/")
 


### PR DESCRIPTION
## Summary
- add a Windows-friendly VideoCatalog launcher with PowerShell/batch entry points and optional shortcut helper
- wire a compatibility shim for `diskscannergui.py`, add an orchestrator CLI heartbeat, and standardise the fixed localhost port (27182)
- update defaults and documentation to reflect the new startup flow and tightened GPU requirements

## Testing
- python -m compileall diskscannergui.py orchestrator/scheduler.py
- python -m compileall orchestrator/scheduler.py

------
https://chatgpt.com/codex/tasks/task_e_68ebc48d73948327b07bc625343e2891