### PR TITLE
Add root START_HERE batch launcher

### DIFF
--- a/START_HERE.bat
+++ b/START_HERE.bat
@@ -1,0 +1,4 @@
+@echo off
+pushd "%~dp0"
+call .\scripts\start_videocatalog.bat %*
+popd


### PR DESCRIPTION
## Summary
- add a root-level START_HERE.bat script that delegates to scripts/start_videocatalog.bat so double-clicking launches the existing starter

## Testing
- cmd.exe /c START_HERE.bat *(fails: Windows cmd.exe is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ebd329650c8327a8b8539abd6075e9