### PR TITLE
Handle missing dependencies in backup and visual review modules

### DIFF
--- a/backup/create.py
+++ b/backup/create.py
@@ -13,15 +13,15 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from api import __version__ as APP_VERSION
-
 from core.db import backup_sqlite, connect
 from core.paths import get_catalog_db_path, get_data_dir, get_logs_dir, get_shards_dir
+from core.versioning import get_app_version
 
 from .errors import BackupError
 from .logs import BackupLogger
 from .types import BackupArtifact, BackupManifest, BackupOptions, BackupResult
 
+APP_VERSION = get_app_version()
 _BACKUP_VERSION = 1
 _LOG_TAIL_BYTES = 5 * 1024 * 1024
 _MAX_THUMB_EXPORT_BYTES = 20 * 1024 * 1024

--- a/backup/restore.py
+++ b/backup/restore.py
@@ -7,12 +7,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List
 
-from api import __version__ as APP_VERSION
-
 from core.db import connect
+from core.versioning import get_app_version
 
 from .errors import BackupError, BackupRestoreError
 from .logs import BackupLogger
+
+APP_VERSION = get_app_version()
 
 
 def _load_manifest(path: Path) -> Dict[str, object]:

--- a/core/versioning.py
+++ b/core/versioning.py
@@ -1,0 +1,76 @@
+"""Helpers for resolving the running VideoCatalog application version."""
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sys
+from functools import lru_cache
+from pathlib import Path
+from types import ModuleType
+from typing import Optional
+
+_API_PACKAGE = "api"
+_API_INIT = Path(__file__).resolve().parent.parent / _API_PACKAGE / "__init__.py"
+
+
+def _module_matches_repo(module: ModuleType) -> bool:
+    """Return ``True`` if ``module`` refers to the repository ``api`` package."""
+    module_path = getattr(module, "__file__", None)
+    if not module_path:
+        return False
+    try:
+        return Path(module_path).resolve() == _API_INIT
+    except OSError:
+        return False
+
+
+def _load_repo_api_module() -> Optional[ModuleType]:
+    """Load the repository ``api`` package if available on the import path."""
+    module = sys.modules.get(_API_PACKAGE)
+    if module and _module_matches_repo(module):
+        return module
+    try:
+        module = importlib.import_module(_API_PACKAGE)
+    except Exception:
+        return None
+    return module if _module_matches_repo(module) else None
+
+
+def _load_version_from_file() -> Optional[str]:
+    """Load ``__version__`` from the repository ``api`` package file."""
+    if not _API_INIT.exists():
+        return None
+    spec = importlib.util.spec_from_file_location("videocatalog.api", _API_INIT)
+    if not spec or not spec.loader:
+        return None
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)  # type: ignore[union-attr]
+    except Exception:
+        return None
+    version = getattr(module, "__version__", None)
+    return str(version) if isinstance(version, str) else None
+
+
+@lru_cache(maxsize=1)
+def get_app_version() -> str:
+    """Return the VideoCatalog application version string.
+
+    This helper avoids accidental imports of similarly named test modules (for
+    example ``tests/api.py``) by verifying the resolved module path. When the
+    package cannot be imported it falls back to loading ``__init__.py`` from the
+    repository directly and ultimately to a safe default.
+    """
+
+    module = _load_repo_api_module()
+    if module is not None:
+        version = getattr(module, "__version__", None)
+        if isinstance(version, str):
+            return version
+    version = _load_version_from_file()
+    if version:
+        return version
+    return "0.0.0"
+
+
+__all__ = ["get_app_version"]

--- a/diskmark/marker.py
+++ b/diskmark/marker.py
@@ -9,13 +9,11 @@ from pathlib import Path
 from typing import Any, Mapping, Optional
 
 from core.settings import update_settings
+from core.versioning import get_app_version
 
 from .checks import MARKER_SCHEMA, compute_signature, validate_marker
 
-try:  # pragma: no cover - best effort import
-    from api import __version__ as APP_VERSION
-except Exception:  # pragma: no cover - fallback when API package unavailable
-    APP_VERSION = "0.0.0"
+APP_VERSION = get_app_version()
 
 APP_NAME = "VideoCatalog"
 

--- a/videocatalog_api.py
+++ b/videocatalog_api.py
@@ -9,12 +9,12 @@ from typing import List, Optional, Sequence
 
 import uvicorn
 
-from api import __version__ as API_VERSION
 from api.db import DataAccess
 from api.server import APIServerConfig, create_app
 from catalog.exporter import export_catalog
 from core.paths import resolve_working_dir
 from core.settings import load_settings
+from core.versioning import get_app_version
 
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 27182
@@ -132,7 +132,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         data_access=data_access,
         api_key=api_key,
         cors_origins=cors,
-        app_version=API_VERSION,
+        app_version=get_app_version(),
         lan_only=lan_refuse,
     )
     app = create_app(config)

--- a/visualreview/pillow_support.py
+++ b/visualreview/pillow_support.py
@@ -1,0 +1,76 @@
+"""Shared helpers for optional Pillow integration in visual review modules."""
+from __future__ import annotations
+
+import logging
+from functools import lru_cache
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing aid only
+    from PIL import Image as PILImage
+
+    PillowImage = PILImage.Image
+else:  # pragma: no cover - runtime fallback when Pillow is absent
+    PillowImage = Any
+
+LOGGER = logging.getLogger("videocatalog.visualreview.frames")
+
+
+class PillowUnavailableError(RuntimeError):
+    """Raised when Pillow is required but not installed."""
+
+
+def _missing_pillow() -> PillowUnavailableError:
+    return PillowUnavailableError(
+        "Pillow is required for visual review features. Install the 'pillow' package."
+    )
+
+
+@lru_cache(maxsize=1)
+def load_pillow_image():  # type: ignore[no-untyped-def]
+    """Return the Pillow Image module or raise :class:`PillowUnavailableError`."""
+
+    try:
+        from PIL import Image as pillow_image  # type: ignore[import-untyped]
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency guard
+        raise _missing_pillow() from exc
+    return pillow_image
+
+
+@lru_cache(maxsize=1)
+def load_pillow_ops():  # type: ignore[no-untyped-def]
+    """Return the Pillow ImageOps module if available."""
+
+    try:
+        from PIL import ImageOps as pillow_ops  # type: ignore[import-untyped]
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency guard
+        raise _missing_pillow() from exc
+    return pillow_ops
+
+
+_PIL_WARNING_EMITTED = False
+
+
+def ensure_pillow(logger: logging.Logger = LOGGER) -> bool:
+    """Return ``True`` when Pillow is available, logging a warning otherwise."""
+
+    global _PIL_WARNING_EMITTED
+    try:
+        load_pillow_image()
+        return True
+    except PillowUnavailableError:
+        if not _PIL_WARNING_EMITTED:
+            logger.warning(
+                "Pillow is not available; visual review image processing is disabled."
+            )
+            _PIL_WARNING_EMITTED = True
+        return False
+
+
+__all__ = [
+    "PillowImage",
+    "PillowUnavailableError",
+    "ensure_pillow",
+    "load_pillow_image",
+    "load_pillow_ops",
+    "LOGGER",
+]


### PR DESCRIPTION
## Summary
- add a shared helper to resolve the VideoCatalog application version without importing test modules
- update backup, disk marker, and API entry points to rely on the new version helper
- add optional Pillow guards across visualreview components so they fail gracefully when the library is absent

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ebd664127883278d986d35fa88cd1a