### PR TITLE
Handle ConvertFrom-Json depth compatibility in launcher

### DIFF
--- a/scripts/start_videocatalog.ps1
+++ b/scripts/start_videocatalog.ps1
@@ -92,7 +92,11 @@ try {
     }
 
     try {
-        $settings = $settingsRaw | ConvertFrom-Json -Depth 100
+        $convertFromJsonParameters = @{ InputObject = $settingsRaw }
+        if ((Get-Command ConvertFrom-Json).Parameters.ContainsKey('Depth')) {
+            $convertFromJsonParameters['Depth'] = 100
+        }
+        $settings = ConvertFrom-Json @convertFromJsonParameters
     } catch {
         Write-Warn 'settings.json is invalid JSON. Recreating defaults.'
         $settings = [pscustomobject]@{}


### PR DESCRIPTION
## Summary
- make the VideoCatalog Windows launcher compatible with PowerShell 5.1 by avoiding unsupported ConvertFrom-Json parameters
- retain deep JSON parsing on newer PowerShell versions by conditionally adding the Depth argument

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ebe94ed3308327981b9530955cb50f