### PR TITLE
Fix pdfminer.six version for Windows dependencies

### DIFF
--- a/requirements-windows.txt
+++ b/requirements-windows.txt
@@ -17,7 +17,7 @@ tmdbsimple==2.9.1
 IMDbPY==2022.7.9
 requests==2.32.3
 PyMuPDF==1.24.10
-pdfminer.six==20240716
+pdfminer.six==20240706
 EbookLib==0.18
 pytesseract==0.3.10
 transformers==4.44.2


### PR DESCRIPTION
## Summary
- adjust the Windows requirements to install pdfminer.six 20240706, a build compatible with Python 3.10

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ec0c3851b8832787f2fdaf4cdd03b2