### PR TITLE
Fix Windows langgraph dependency pin

### DIFF
--- a/requirements-windows.txt
+++ b/requirements-windows.txt
@@ -23,7 +23,7 @@ pytesseract==0.3.10
 transformers==4.44.2
 yake==0.4.8
 langdetect==1.0.9
-langgraph==0.1.0
+langgraph==0.1.11
 langchain-core==0.2.34
 langchain-community==0.2.12
 sentence-transformers==3.0.1


### PR DESCRIPTION
## Summary
- update the Windows-specific requirements to pin langgraph to version 0.1.11, which is published for Python 3.10
- unblock the Windows launcher by ensuring the dependency can be installed

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ec0f167bac83278b602d67e770840a