### PR TITLE
Fix Windows llama.cpp dependency fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ Utilities for scanning large removable media libraries and keeping a SQLite-base
 - Heavy assistant workloads require an NVIDIA GPU with at least 8 GB of free VRAM. The bootstrap checks NVML and `nvidia-smi`; if
   neither are available it writes `logs\gpu.disabled.banner` and the assistant API responds with
   `AI disabled (GPU required: <reason>)`.
+- The bundled dependency manifest installs the CPU wheel of `llama-cpp-python==0.2.90` on Windows because the
+  `llama-cpp-python-cuBLAS` project does not publish Windows binaries. GPU acceleration remains available, but you must
+  install a compatible build manually after stabilization completes—for example by compiling the project with CMake and
+  CUDA or by installing a wheel published by the llama.cpp release artifacts. Once the GPU-enabled build is in place,
+  rerun `stabilize.ps1 -SkipInstall` to reuse the existing environment.
 - When the GPU probe fails, install the latest NVIDIA Studio/Game Ready driver and rerun `stabilize.ps1`. If CUDA support is
   missing, install the CUDA Toolkit (`winget install -e --id Nvidia.CUDA`) followed by `pip install --upgrade onnxruntime-gpu`.
 - `ffprobe` is required for the `quality_headers` smoke test. Install FFmpeg and ensure `ffprobe.exe` resolves on `PATH`. Until

--- a/requirements-windows.txt
+++ b/requirements-windows.txt
@@ -29,5 +29,7 @@ langchain-community==0.2.12
 sentence-transformers==3.0.1
 huggingface-hub==0.24.6
 hnswlib==0.8.0
-llama-cpp-python-cuBLAS==0.2.90
+# llama-cpp-python-cuBLAS wheels are not published for Windows; use the CPU build instead.
+# GPU acceleration can still be enabled manually by following the README instructions.
+llama-cpp-python==0.2.90
 faiss-cpu==1.7.4


### PR DESCRIPTION
## Summary
- replace the Windows dependency on `llama-cpp-python-cuBLAS` with the portable CPU wheel that is published for Python 3.10
- document how Windows users can manually install a GPU-enabled llama.cpp build after stabilization completes

## Testing
- not run (docs and dependency manifest update only)


------
https://chatgpt.com/codex/tasks/task_e_68ec10535fec8327b73f62fb84ab32b4