### PR TITLE
Handle optional Windows dependencies more gracefully

### DIFF
--- a/requirements-windows.txt
+++ b/requirements-windows.txt
@@ -28,8 +28,7 @@ langchain-core==0.2.34
 langchain-community==0.2.12
 sentence-transformers==3.0.1
 huggingface-hub==0.24.6
-hnswlib==0.8.0
-# llama-cpp-python-cuBLAS wheels are not published for Windows; use the CPU build instead.
-# GPU acceleration can still be enabled manually by following the README instructions.
-llama-cpp-python==0.2.90
 faiss-cpu==1.7.4
+#
+# Optional dependencies (llama-cpp-python, hnswlib) are installed by the Windows launcher so
+# it can provide clearer error messages and continue when build tools are unavailable.


### PR DESCRIPTION
## Summary
- add a reusable helper to run pip so Windows launcher can react to failure codes
- install base requirements first and then attempt optional Windows wheels with clearer messaging
- remove optional llama-cpp-python and hnswlib from the Windows requirements file so the launcher controls their installation flow

## Testing
- not run (PowerShell launcher changes only)


------
https://chatgpt.com/codex/tasks/task_e_68ec11ba68d483279da81c59cc5ff1ea