### PR TITLE
Handle FAISS install failure on Windows

### DIFF
--- a/requirements-windows.txt
+++ b/requirements-windows.txt
@@ -28,7 +28,8 @@ langchain-core==0.2.34
 langchain-community==0.2.12
 sentence-transformers==3.0.1
 huggingface-hub==0.24.6
-faiss-cpu==1.7.4
+# FAISS is installed separately by the launcher so Windows users without build tools can
+# still start the application and receive a helpful warning instead of a hard failure.
 #
 # Optional dependencies (llama-cpp-python, hnswlib) are installed by the Windows launcher so
 # it can provide clearer error messages and continue when build tools are unavailable.

--- a/scripts/start_videocatalog.ps1
+++ b/scripts/start_videocatalog.ps1
@@ -299,6 +299,13 @@ try {
             FailureMessage = 'Falling back to FAISS/simple similarity search. Install the Visual C++ Build Tools to enable the hnswlib backend.'
         }
 
+        $optionalPackages += [pscustomobject]@{
+            Name = 'faiss-cpu'
+            Requirement = 'faiss-cpu==1.7.4'
+            ForceBinary = $true
+            FailureMessage = 'Falling back to simple similarity search. Install FAISS manually to enable the FAISS backend.'
+        }
+
         foreach ($package in $optionalPackages) {
             if (-not $package.Requirement) { continue }
             $args = @('install')


### PR DESCRIPTION
## Summary
- stop requiring faiss-cpu during the base Windows dependency install so setup no longer fails when the wheel is unavailable
- attempt to install faiss-cpu as an optional dependency in the launcher and fall back gracefully when it cannot be installed

## Testing
- not run (PowerShell script change)


------
https://chatgpt.com/codex/tasks/task_e_68ec23b255f883278f2eea8c89a32829