### PR TITLE
Fix PowerShell string interpolation issues

### DIFF
--- a/scripts/start_videocatalog.ps1
+++ b/scripts/start_videocatalog.ps1
@@ -63,7 +63,7 @@ function Invoke-PipInstall {
         }
 
         $timestamp = Get-Date -Format o
-        $commandLine = "\"$commandPath\" $($commandArgs -join ' ')"
+        $commandLine = "`"$commandPath`" $($commandArgs -join ' ')"
         Add-Content -Path $LogFile -Value "[$timestamp] COMMAND: $commandLine" -Encoding UTF8
         try {
             & $commandPath @commandArgs 2>&1 | Tee-Object -FilePath $LogFile -Append
@@ -137,7 +137,7 @@ try {
     "VideoCatalog pip session log started $(Get-Date -Format o)" | Set-Content -Path $pipLog -Encoding UTF8
     Write-Info "Pip output will be logged to $pipLog"
 } catch {
-    Write-Warn "Unable to initialize pip log at $pipLog: $($_.Exception.Message)"
+    Write-Warn "Unable to initialize pip log at ${pipLog}: $($_.Exception.Message)"
     $pipLog = $null
 }
 


### PR DESCRIPTION
## Summary
- correct the command logging string in the PowerShell launcher to use proper escaped quotes
- ensure pip log warning message formats the log path correctly when a colon follows the variable

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ec31bd6f2883279578118070291863