### PR TITLE
Update Windows lock workflow and launcher handling

### DIFF
--- a/.github/workflows/windows-deps.yml
+++ b/.github/workflows/windows-deps.yml
@@ -20,17 +20,19 @@ jobs:
     name: Lock dependencies
     runs-on: windows-latest
     steps:
-      - name: Disable line ending conversion
-        run: git config --global core.autocrlf false
       - uses: actions/checkout@v4
+      - name: Disable line ending conversion
+        run: |
+          git config --global core.autocrlf false
+          git config --local core.autocrlf false
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       - name: Upgrade pip tooling
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install pip-tools
+          python -m pip install --upgrade pip --only-binary=:all:
+          python -m pip install pip-tools --only-binary=:all:
       - name: Compile runtime lock
         run: |
           pip-compile --resolver=backtracking --allow-unsafe --strip-extras --generate-hashes --pip-args "--only-binary=:all: --platform win_amd64 --python-version 3.11 --implementation cp --abi cp311" --output-file requirements.txt requirements.in
@@ -52,15 +54,37 @@ jobs:
     name: Install from locks
     needs: lock
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        profile: [cpu, gpu]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Upgrade pip
-        run: python -m pip install --upgrade pip
-      - name: Install runtime lock
-        run: python -m pip install --only-binary=:all: --no-deps -r requirements.txt
+      - name: Create virtual environment
+        run: python -m venv .venv
+      - name: Upgrade pip tooling in venv
+        shell: pwsh
+        run: |
+          .\.venv\Scripts\python.exe -m pip install --upgrade pip setuptools wheel --only-binary=:all:
+      - name: Install runtime dependencies from lock
+        shell: pwsh
+        run: |
+          .\.venv\Scripts\python.exe -m pip install --only-binary=:all: --require-hashes -r requirements.txt
+      - name: Install Windows profile
+        if: matrix.profile == 'cpu'
+        shell: pwsh
+        run: |
+          .\.venv\Scripts\python.exe -m pip install --only-binary=:all: --require-hashes -r profiles/windows-cpu.txt
+      - name: Install Windows GPU profile
+        if: matrix.profile == 'gpu'
+        shell: pwsh
+        run: |
+          .\.venv\Scripts\python.exe -m pip install --only-binary=:all: --require-hashes --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cu121 -r profiles/windows-gpu.txt
       - name: Smoke import
-        run: python -c "import fastapi, uvicorn; print('ok')"
+        shell: pwsh
+        run: |
+          .\.venv\Scripts\python.exe -c "import fastapi, uvicorn; print('ok')"

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ Utilities for scanning large removable media libraries and keeping a SQLite-base
    ```
 
    The script prepares `%USERPROFILE%\VideoCatalog` as the writable home, downloads the assistant warmup models (Qwen2 0.5B
-   instruct GGUF and BGE-small embeddings) into `working_dir\models`, installs the pinned dependencies from
-   `profiles\windows-cpu.txt` (or `profiles\windows-gpu.txt` when running with CUDA), runs SQLite migrations via `upgrade_db.py`, starts the local API (bound to `127.0.0.1:27182`), and
+   instruct GGUF and BGE-small embeddings) into `working_dir\models`, installs the pinned wheel-only dependencies from the
+   Windows lockfiles (`profiles\windows-cpu.txt` by default or `profiles\windows-gpu.txt` when CUDA prerequisites are
+   satisfied) with `pip --require-hashes --only-binary=:all:`, runs SQLite migrations via `upgrade_db.py`, starts the local API (bound to `127.0.0.1:27182`), and
    executes the HTTP preflight/smoke diagnostics. Logs stream to `working_dir\logs\stabilize.log` and are also mirrored in the
    console. Rerun with `-SkipInstall` to reuse an existing virtual environment.
 
@@ -49,11 +50,10 @@ Utilities for scanning large removable media libraries and keeping a SQLite-base
 - Heavy assistant workloads require an NVIDIA GPU with at least 8 GB of free VRAM. The bootstrap checks NVML and `nvidia-smi`; if
   neither are available it writes `logs\gpu.disabled.banner` and the assistant API responds with
   `AI disabled (GPU required: <reason>)`.
-- The bundled dependency manifest installs the CPU wheel of `llama-cpp-python==0.2.90` on Windows because the
-  `llama-cpp-python-cuBLAS` project does not publish Windows binaries. GPU acceleration remains available, but you must
-  install a compatible build manually after stabilization completes—for example by compiling the project with CMake and
-  CUDA or by installing a wheel published by the llama.cpp release artifacts. Once the GPU-enabled build is in place,
-  rerun `stabilize.ps1 -SkipInstall` to reuse the existing environment.
+- The GPU lockfile resolves `llama-cpp-python==0.2.90` from the CUDA wheels published at
+  `https://abetlen.github.io/llama-cpp-python/whl/cu121`. If those wheels are unavailable (or if the host lacks CUDA
+  requirements), the launcher automatically falls back to the CPU profile so you can continue using the application without
+  rebuilding from source.
 - When the GPU probe fails, install the latest NVIDIA Studio/Game Ready driver and rerun `stabilize.ps1`. If CUDA support is
   missing, install the CUDA Toolkit (`winget install -e --id Nvidia.CUDA`) followed by `pip install --upgrade onnxruntime-gpu`.
 - `ffprobe` is required for the `quality_headers` smoke test. Install FFmpeg and ensure `ffprobe.exe` resolves on `PATH`. Until

--- a/profiles/windows-gpu.txt
+++ b/profiles/windows-gpu.txt
@@ -788,7 +788,7 @@ langgraph==0.6.10 \
     --hash=sha256:b16baacd38895f6f4aa51e03b8a5b5f8695cff96fd0e8b637b725186ea27237c
     # via -r requirements.in
 llama-cpp-python==0.2.90 \
-    --hash=sha256:407d15fbb46ff33d8d8259a9826d23b9b127d3c280aecd92121623eb4a84f67a
+    --hash=sha256:7065885658ba26d9cce6ad2cd0e50ae10698c91e5e6dd48df790ef47abd92bdf
     # via -r profiles/windows-gpu.in
 langgraph-checkpoint==2.1.2 \
     --hash=sha256:911ebffb069fd01775d4b5184c04aaafc2962fcdf50cf49d524cd4367c4d0c60

--- a/scripts/start_videocatalog.ps1
+++ b/scripts/start_videocatalog.ps1
@@ -300,6 +300,8 @@ try {
 
     $env:VIDEOCATALOG_HOME = $workFull
     $env:PYTHONUNBUFFERED = '1'
+    $env:PIP_DISABLE_PIP_VERSION_CHECK = '1'
+    Write-Info 'Disabled pip version check for child processes.'
 
     Write-Info 'Upgrading pip, setuptools, and wheel in the virtual environment.'
     $bootstrapArgs = @('install', '--upgrade', 'pip', 'setuptools', 'wheel')
@@ -308,7 +310,11 @@ try {
     $bootstrapExit = Invoke-PipInstall -Arguments $bootstrapArgs -PythonExe $pythonExe -PipExe $null -LogFile $pipLog
     if ($bootstrapExit -ne 0) {
         $logHint = if ($pipLog) { " Review pip log at $pipLog." } else { '' }
-        Write-Warn "Failed to upgrade pip/setuptools/wheel (exit code $bootstrapExit). Continuing with existing versions.$logHint"
+        if ($bootstrapExit -eq -1) {
+            Write-Warn "pip upgrade completed with warnings (exit code -1). Continuing with detected versions.$logHint"
+        } else {
+            Write-Warn "Failed to upgrade pip/setuptools/wheel (exit code $bootstrapExit). Continuing with existing versions.$logHint"
+        }
     } else {
         if (-not $pipExe -and (Test-Path $venvPip)) {
             $pipExe = $venvPip


### PR DESCRIPTION
## Summary
- enforce wheel-only locking and venv-based installs in the Windows dependency workflow, including a CPU/GPU matrix
- document wheel-only, hash-locked Windows installs and refresh the GPU lockfile to reference the CUDA llama-cpp-python wheel
- disable pip version check warnings in the Windows launcher so pip upgrades no longer fail the bootstrap

## Testing
- not run (CI)

------
https://chatgpt.com/codex/tasks/task_e_68ed378dc85c8327908b715c8fc3d6f3