### PR TITLE
Fix Windows dependency workflow verification and pip warning

### DIFF
--- a/.github/workflows/windows-deps.yml
+++ b/.github/workflows/windows-deps.yml
@@ -49,15 +49,10 @@ jobs:
         run: .\.venv\Scripts\python -m piptools compile --resolver=backtracking --allow-unsafe --strip-extras --generate-hashes --pip-args="--only-binary=:all:" -o profiles/windows-cpu.txt profiles/windows-cpu.in
       - name: Compile Windows GPU lock
         run: .\.venv\Scripts\python -m piptools compile --resolver=backtracking --allow-unsafe --strip-extras --generate-hashes --pip-args="--only-binary=:all: --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cu121" -o profiles/windows-gpu.txt profiles/windows-gpu.in
-      - name: Verify lockfiles unchanged
+      - name: Verify lock files committed
         run: |
           git diff --stat -- requirements.txt requirements-dev.txt profiles/windows-cpu.txt profiles/windows-gpu.txt
           git diff --exit-code -- requirements.txt requirements-dev.txt profiles/windows-cpu.txt profiles/windows-gpu.txt
-          if ($LASTEXITCODE -ne 0) {
-            Write-Error "Locks drifted. Run pip-compile on Windows and commit the results."
-            $host.SetShouldExit(1)
-            return
-          }
 
   install:
     name: Install from locks (${{ matrix.profile }})

--- a/scripts/start_videocatalog.ps1
+++ b/scripts/start_videocatalog.ps1
@@ -4,6 +4,7 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+$env:PIP_DISABLE_PIP_VERSION_CHECK = '1'
 
 function Write-Info {
     param([string]$Message)


### PR DESCRIPTION
## Summary
- ensure the Windows dependency workflow uses PowerShell 7-friendly lock verification that fails on real diffs
- suppress the pip version check in the Windows launcher to avoid benign warnings during bootstrap

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68ed6ed02a6883278d4634c9be098eb8