### PR TITLE
Standardize Windows dependencies on Python 3.12

### DIFF
--- a/.github/workflows/windows-deps.yml
+++ b/.github/workflows/windows-deps.yml
@@ -36,25 +36,47 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Create virtual environment
         run: python -m venv .venv
       - name: Install pip-tools
         run: .\.venv\Scripts\python -m pip install --disable-pip-version-check --only-binary=:all: pip-tools
       - name: Compile runtime lock
-        run: .\.venv\Scripts\python -m piptools compile --resolver=backtracking --allow-unsafe --strip-extras --generate-hashes '--pip-args "--disable-pip-version-check --only-binary=:all:"' -o requirements.txt requirements.in
+        if: matrix.profile == 'cpu'
+        run: .\.venv\Scripts\python -m piptools compile --resolver=backtracking --allow-unsafe --strip-extras --generate-hashes --only-binary=:all: --pip-args "--disable-pip-version-check" -o requirements.txt requirements.in
       - name: Compile dev lock
-        run: .\.venv\Scripts\python -m piptools compile --resolver=backtracking --allow-unsafe --strip-extras --generate-hashes '--pip-args "--disable-pip-version-check --only-binary=:all:"' -o requirements-dev.txt requirements-dev.in
+        if: matrix.profile == 'cpu'
+        run: .\.venv\Scripts\python -m piptools compile --resolver=backtracking --allow-unsafe --strip-extras --generate-hashes --only-binary=:all: --pip-args "--disable-pip-version-check" -o requirements-dev.txt requirements-dev.in
       - name: Compile Windows CPU lock
-        run: .\.venv\Scripts\python -m piptools compile --resolver=backtracking --allow-unsafe --strip-extras --generate-hashes '--pip-args "--disable-pip-version-check --only-binary=:all:"' -o profiles/windows-cpu.txt profiles/windows-cpu.in
+        if: matrix.profile == 'cpu'
+        run: .\.venv\Scripts\python -m piptools compile --resolver=backtracking --allow-unsafe --strip-extras --generate-hashes --only-binary=:all: --pip-args "--disable-pip-version-check" -o profiles/windows-cpu.txt profiles/windows-cpu.in
       - name: Compile Windows GPU lock
-        run: .\.venv\Scripts\python -m piptools compile --resolver=backtracking --allow-unsafe --strip-extras --generate-hashes '--pip-args "--disable-pip-version-check --only-binary=:all: --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cu121"' -o profiles/windows-gpu.txt profiles/windows-gpu.in
-      - name: Verify lock files committed
+        if: matrix.profile == 'gpu'
+        run: .\.venv\Scripts\python -m piptools compile --resolver=backtracking --allow-unsafe --strip-extras --generate-hashes --only-binary=:all: --pip-args "--disable-pip-version-check --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cu121" -o profiles/windows-gpu.txt profiles/windows-gpu.in
+      - name: Verify lock files committed (CPU)
+        if: matrix.profile == 'cpu'
         run: |
-          $lockFiles = @('requirements.txt', 'requirements-dev.txt', 'profiles/windows-cpu.txt', 'profiles/windows-gpu.txt')
-          $diff = git diff --name-only -- $lockFiles
+          $targets = @('requirements.txt', 'requirements-dev.txt', 'profiles/windows-cpu.txt')
+          $diff = git diff --name-only -- $targets
           if ($diff) {
-            git --no-pager diff -- $lockFiles
+            git --no-pager diff --stat -- $targets
+            git --no-pager diff -- $targets
+            Write-Error 'Windows CPU lockfiles are out of date. Regenerate them on Windows with Python 3.12 and commit the result.'
+            exit 1
+          }
+      - name: Verify lock files committed (GPU)
+        if: matrix.profile == 'gpu'
+        run: |
+          $target = 'profiles/windows-gpu.txt'
+          if (-not (Test-Path $target)) {
+            Write-Error "Expected $target to exist after compilation."
+            exit 1
+          }
+          $diff = git diff --name-only -- $target
+          if ($diff) {
+            git --no-pager diff --stat -- $target
+            git --no-pager diff -- $target
+            Write-Error 'Windows GPU lockfile is out of date. Regenerate it on Windows with Python 3.12 and commit the result.'
             exit 1
           }
 
@@ -75,7 +97,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Create virtual environment
         run: python -m venv .venv
       - name: Install shared requirements

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Utilities for scanning large removable media libraries and keeping a SQLite-base
 
 ## Windows 11 bootstrap & stabilization
 
-1. Install the NVIDIA Windows driver and Python 3.11+ (64-bit). Ensure `python` is on your `PATH` when you open PowerShell.
+1. Install the NVIDIA Windows driver and Python 3.12 (64-bit). Ensure the Windows launcher (`py`) or `python.exe` resolves on your `PATH` when you open PowerShell—the launcher refuses to run on older interpreters.
 2. Clone or unpack this repository somewhere under your profile (for example `C:\Users\you\Projects\VideoCatalog`).
 3. Launch an elevated PowerShell prompt, change to the repo root, and run:
 
@@ -29,7 +29,8 @@ Utilities for scanning large removable media libraries and keeping a SQLite-base
 
    The script prepares `%USERPROFILE%\VideoCatalog` as the writable home, downloads the assistant warmup models (Qwen2 0.5B
    instruct GGUF and BGE-small embeddings) into `working_dir\models`, installs the pinned dependencies from
-   `profiles\windows-cpu.txt` (or `profiles\windows-gpu.txt` when running with CUDA), runs SQLite migrations via `upgrade_db.py`, starts the local API (bound to `127.0.0.1:27182`), and
+   `profiles\windows-cpu.txt` (or `profiles\windows-gpu.txt` when running with CUDA) strictly from prebuilt wheels with hash
+   validation, runs SQLite migrations via `upgrade_db.py`, starts the local API (bound to `127.0.0.1:27182`), and
    executes the HTTP preflight/smoke diagnostics. Logs stream to `working_dir\logs\stabilize.log` and are also mirrored in the
    console. Rerun with `-SkipInstall` to reuse an existing virtual environment.
 


### PR DESCRIPTION
## Summary
- update the Windows launcher to prefer `py -3.12`, refuse interpreters older than Python 3.12, and rely on pip exit codes while disabling version checks
- switch the Windows dependency workflow to Python 3.12, rebuild locks with wheel-only/hash options per profile, and fail with clear diffs when regenerated files diverge
- document the Python 3.12 requirement and the wheel-only, hash-validated installs in the Windows bootstrap instructions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ed8c1e404483278a0d573d14287b2f